### PR TITLE
fix: speed up Amplify build by reusing cached node_modules

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -3,7 +3,7 @@ frontend:
   phases:
     preBuild:
       commands:
-        - npm ci
+        - npm install
     build:
       commands:
         - npm run build
@@ -15,3 +15,4 @@ frontend:
     paths:
       - node_modules/**/*
       - .nuxt/**/*
+      - node_modules/.cache/**/*


### PR DESCRIPTION
## Summary
- Switch `npm ci` → `npm install` in `amplify.yml` so the cached `node_modules` directory is reused (~30s savings)
- Add `node_modules/.cache/**/*` to Amplify cache paths for Vite transform cache reuse (~5-10s savings)

## Context
Amplify builds take ~5min vs Netlify's ~2m15s for the same code. The biggest controllable gap is `npm ci` deleting and reinstalling all dependencies despite `node_modules` being cached.

## Expected impact
~30-40s reduction in Amplify build time without any compute upgrade.