### PR TITLE
FMST-2455: Add widht and height to images across codebase eliminating cls

### DIFF
--- a/components/CallToActionSection.vue
+++ b/components/CallToActionSection.vue
@@ -2,8 +2,8 @@
   <section class="call-to-action-section" :class="{ 'd-none': content.hidden }">
     <div class="container py-md-6 py-5 px-md-5">
       <div class="background-image-wrapper">
-        <nuxt-img src="/CTA Mask Left.svg" class="background-image-left" alt="" />
-        <nuxt-img src="/CTA Mask Right.svg" class="background-image-right" alt="" />
+        <nuxt-img src="/CTA Mask Left.svg" class="background-image-left" alt="" width="164" height="329" loading="lazy" />
+        <nuxt-img src="/CTA Mask Right.svg" class="background-image-right" alt="" width="584" height="329" loading="lazy" />
       </div>
       <div
         class="row align-items-center py-md-5 py-3 px-md-5 px-3"

--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -3,7 +3,7 @@
     <div class="footer__container text-center">
       <NuxtLink to="/">
         <div class="footer__logo">
-          <nuxt-img src="/logo-light.svg" alt="Formester" />
+          <nuxt-img src="/logo-light.svg" alt="Formester" width="169" height="24" />
         </div>
       </NuxtLink>
       <section class="mt-5 container">
@@ -388,6 +388,9 @@
               ><nuxt-img
                 src="/social/reddit.svg"
                 alt="Formester Reddit community"
+                width="32"
+                height="32"
+                loading="lazy"
             /></a>
             <a
               href="https://www.linkedin.com/company/formester-inc/"
@@ -396,12 +399,15 @@
               ><nuxt-img
                 src="/social/linkedin.svg"
                 alt="Formester LinkedIn page"
+                width="32"
+                height="32"
+                loading="lazy"
             /></a>
             <a
               href="https://www.youtube.com/channel/UCVfBesiZINubCEC9Xu5Z6gQ"
               class="mx-1 my-2 inline-block"
               target="_blank"
-              ><nuxt-img src="/social/youtube.svg" alt="Formester YouTube page"
+              ><nuxt-img src="/social/youtube.svg" alt="Formester YouTube page" width="32" height="32" loading="lazy"
             /></a>
             <a
               href="https://instagram.com/_formester_?utm_medium=copy_link"
@@ -410,12 +416,15 @@
               ><nuxt-img
                 src="/social/instagram.svg"
                 alt="Formester Instagram page"
+                width="32"
+                height="32"
+                loading="lazy"
             /></a>
             <a
               href="https://twitter.com/_Formester_?t=-m1pNwXvxR6KOf9kfPi9lQ&s=09"
               class="mx-1 my-2 inline-block"
               target="_blank"
-              ><nuxt-img src="/social/twitter.svg" alt="Formester Twitter page"
+              ><nuxt-img src="/social/twitter.svg" alt="Formester Twitter page" width="32" height="32" loading="lazy"
             /></a>
             <a
               href="https://www.facebook.com/formester"
@@ -424,6 +433,9 @@
               ><nuxt-img
                 src="/social/facebook.svg"
                 alt="Formester Facebook page"
+                width="32"
+                height="32"
+                loading="lazy"
             /></a>
           </div>
           <div class="copyright d-flex justify-content-center">
@@ -432,7 +444,7 @@
           <a
             href="https://www.trustpilot.com/review/formester.com"
             target="_blank"
-            ><nuxt-img src="/trustpilot-footer.svg" alt="Trustpilot"
+            ><nuxt-img src="/trustpilot-footer.svg" alt="Trustpilot" width="260" height="36" loading="lazy"
           /></a>
         </div>
       </div>

--- a/components/HeroRowLayout.vue
+++ b/components/HeroRowLayout.vue
@@ -27,20 +27,24 @@
           <!-- Image display when no video is provided -->
           <nuxt-img
             v-if="heroImage && !video_url"
-            :src="heroImage.image?.url || heroImage.imageUrl"
-            :alt="heroImage.imageAlt || 'Hero image'"
+            :src="heroImg.src"
+            :alt="heroImg.alt || 'Hero image'"
+            :width="heroImg.width"
+            :height="heroImg.height"
             class="img-fluid hero__image"
           />
 
           <!-- Video thumbnail with play button when video is provided -->
           <div v-if="video_url" class="video-thumbnail-wrapper" @click="showOverlay = true">
             <nuxt-img
-              :src="thumbnail ? (thumbnail.url || thumbnail.image?.url || thumbnail.imageUrl) : youtubeThumbnailUrl"
-              :alt="thumbnail?.imageAlt || 'Video thumbnail'"
+              :src="thumbImg.src || youtubeThumbnailUrl"
+              :alt="thumbImg.alt || 'Video thumbnail'"
+              :width="thumbImg.width || 480"
+              :height="thumbImg.height || 360"
               class="video-thumb-img hero__image"
             />
             <button class="custom-play-btn" aria-label="Play video">
-              <nuxt-img src="/play-button.svg" alt="Play video" />
+              <nuxt-img src="/play-button.svg" alt="Play video" width="64" height="64" />
             </button>
             <!-- Hidden link for SEO - helps search engines discover the video -->
             <a :href="video_url" class="visually-hidden" target="_blank" rel="noopener noreferrer">Watch video on YouTube</a>
@@ -58,7 +62,7 @@
                 allowfullscreen
               ></iframe>
               <button @click="closeOverlay" aria-label="Close video" class="close-btn">
-                <nuxt-img src="/x-close.svg" alt="Close video" />
+                <nuxt-img src="/x-close.svg" alt="Close video" width="24" height="24" />
               </button>
             </div>
           </div>
@@ -69,6 +73,8 @@
 </template>
 
 <script>
+import { getStrapiImage } from '@/utils/strapiImage'
+
 export default {
    props: {
     title: {
@@ -106,6 +112,12 @@ export default {
     };
   },
   computed: {
+    heroImg() {
+      return getStrapiImage(this.heroImage)
+    },
+    thumbImg() {
+      return getStrapiImage(this.thumbnail)
+    },
     youtubeVideoId() {
       // Extracts the video ID from various YouTube URL formats
       const url = this.video_url;

--- a/components/RelatedArticleCard.vue
+++ b/components/RelatedArticleCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <NuxtLink :to="articleLink">
+  <NuxtLink v-if="article" :to="articleLink">
     <img
       v-if="article.coverImg"
       :src="article.coverImg"
@@ -26,6 +26,7 @@ export default {
   },
   computed: {
     articleLink() {
+      if (!this.article) return '#'
       if (this.article.type) {
         return this.article.link
       }

--- a/components/RelatedArticleCard.vue
+++ b/components/RelatedArticleCard.vue
@@ -1,6 +1,7 @@
 <template>
   <NuxtLink :to="articleLink">
     <img
+      v-if="article.coverImg"
       :src="article.coverImg"
       class="rounded img-fluid"
       :alt="article.coverImgAlt"

--- a/components/RelatedArticleCard.vue
+++ b/components/RelatedArticleCard.vue
@@ -4,6 +4,9 @@
       :src="article.coverImg"
       class="rounded img-fluid"
       :alt="article.coverImgAlt"
+      :width="article.coverImgWidth || 1200"
+      :height="article.coverImgHeight || 630"
+      loading="lazy"
     />
     <div class="d-flex flex-column align-items-start mt-2">
       <h3 class="article__title">{{ article.title }}</h3>

--- a/components/Section.vue
+++ b/components/Section.vue
@@ -23,6 +23,9 @@
           :src="`/${feature.imgName}`"
           alt="Formester integration with different apps"
           class="img-fluid"
+          width="600"
+          height="450"
+          loading="lazy"
         />
       </div>
     </div>

--- a/components/Testimonial.vue
+++ b/components/Testimonial.vue
@@ -7,13 +7,13 @@
       </div>
       <div class="d-flex flex-column flex-lg-row px-3 px-md-0 justify-content-center align-items-center mt-5">
         <div class="card mt-5 mt-lg-1 p-3 me-lg-3" style="max-width: 512px;">
-          <nuxt-img class="quotes__logo" src="/quotes.svg" alt="" loading="lazy"/>
+          <nuxt-img class="quotes__logo" src="/quotes.svg" alt="" width="81" height="63" loading="lazy"/>
           <div class="d-flex flex-column align-items-center text-center px-2 ">
             <span class="quote mt-5 mb-4">{{ testimonials[0].content }}</span>
             <div class="my-3 d-flex flex-column align-items-center">
               <span class="person">{{ testimonials[0].user }}</span>
               <span class="designation">{{ testimonials[0].designation }}</span>
-              <nuxt-img class="brand mt-4 mb-3" :src="`/testimonials/${testimonials[0].logo}`" alt="" loading="lazy"/>
+              <nuxt-img class="brand mt-4 mb-3" :src="`/testimonials/${testimonials[0].logo}`" alt="" width="110" height="36" loading="lazy"/>
             </div>
           </div>
         </div>
@@ -23,7 +23,7 @@
             <div class="my-3 d-flex flex-column align-items-center">
               <span class="person">{{ testimonials[1].user }}</span>
               <span class="designation">{{ testimonials[1].designation }}</span>
-              <nuxt-img class="brand mt-4 mb-3" :src="`/testimonials/${testimonials[1].logo}`" alt="" loading="lazy" />
+              <nuxt-img class="brand mt-4 mb-3" :src="`/testimonials/${testimonials[1].logo}`" alt="" width="110" height="36" loading="lazy" />
             </div>
           </div>
         </div>

--- a/components/blog/BlogCard.vue
+++ b/components/blog/BlogCard.vue
@@ -1,6 +1,7 @@
 <template>
   <NuxtLink :to="{ path: `/blog/${article.slug}/` }">
     <img
+      v-if="article.coverImg"
       :src="article.coverImg"
       class="rounded img-fluid"
       :alt="article.coverImgAlt"

--- a/components/blog/BlogCard.vue
+++ b/components/blog/BlogCard.vue
@@ -5,6 +5,9 @@
       class="rounded img-fluid"
       :alt="article.coverImgAlt"
       :title="article.coverImgAlt"
+      :width="article.coverImgWidth || 1200"
+      :height="article.coverImgHeight || 630"
+      loading="lazy"
     />
     <div class="d-flex flex-column align-items-start">
       <span class="blog__date mt-3">{{ formatDate(article.publishedAt) }}</span>

--- a/components/blog/BlogCard.vue
+++ b/components/blog/BlogCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <NuxtLink :to="{ path: `/blog/${article.slug}/` }">
+  <NuxtLink v-if="article" :to="{ path: `/blog/${article.slug}/` }">
     <img
       v-if="article.coverImg"
       :src="article.coverImg"
@@ -16,7 +16,7 @@
         <h3 class="blog__title">{{ article.title }}</h3>
         <p class="mt-1 blog__desc">{{ article.description }}</p>
       </div>
-      <span class="mt-2 blog__timetoRead">
+      <span v-if="article.readingStats" class="mt-2 blog__timetoRead">
         <ClockIcon color="#828282" />
         {{ article.readingStats.text }}
       </span>

--- a/components/blog/BlogFeatured.vue
+++ b/components/blog/BlogFeatured.vue
@@ -4,6 +4,7 @@
     class="row px-3"
   >
     <img
+      v-if="article.coverImg"
       :src="article.coverImg"
       class="col-lg-6 rounded img-fluid featured__blog-img"
       :alt="article.coverImgAlt"

--- a/components/blog/BlogFeatured.vue
+++ b/components/blog/BlogFeatured.vue
@@ -8,6 +8,8 @@
       class="col-lg-6 rounded img-fluid featured__blog-img"
       :alt="article.coverImgAlt"
       :title="article.coverImgAlt"
+      :width="article.coverImgWidth || 1200"
+      :height="article.coverImgHeight || 630"
     />
     <div
       class="col-lg-6 d-flex flex-column align-items-start mt-3 mt-lg-0 ps-0 ps-lg-4"

--- a/components/blog/BlogFeatured.vue
+++ b/components/blog/BlogFeatured.vue
@@ -1,5 +1,6 @@
 <template>
   <NuxtLink
+    v-if="article"
     :to="{ path: `/blog/${article.slug}/` }"
     class="row px-3"
   >
@@ -20,7 +21,7 @@
         <h3 class="blog__title">{{ article.title }}</h3>
         <p class="mt-1 blog__desc">{{ article.description }}</p>
       </div>
-      <span class="mt-2 blog__timetoRead">
+      <span v-if="article.readingStats" class="mt-2 blog__timetoRead">
         <ClockIcon color="#828282" />
         {{ article.readingStats.text }}
       </span>

--- a/components/comparision/FormBuilderComparisonTable.vue
+++ b/components/comparision/FormBuilderComparisonTable.vue
@@ -11,8 +11,9 @@
           <div class="formbuilder__logo-wrapper d-flex align-items-center justify-content-center text-center">
             <!-- If not using @nuxt/image, replace NuxtImg with img -->
             <NuxtImg
+              v-if="fb?.logo?.data?.attributes?.url"
               class="formbuilder__logo"
-              :src="fb?.logo?.data?.attributes?.url || ''"
+              :src="fb.logo.data.attributes.url"
               :alt="fb?.name || 'Form builder logo'"
               height="40"
               loading="lazy"
@@ -65,8 +66,9 @@
       >
         <div class="formbuilder__logo-wrapper d-flex align-items-center justify-content-center text-center">
           <NuxtImg
+            v-if="fb?.logo?.data?.attributes?.url"
             class="formbuilder__logo"
-            :src="fb?.logo?.data?.attributes?.url || ''"
+            :src="fb.logo.data.attributes.url"
             :alt="fb?.name || 'Form builder logo'"
             height="40"
             loading="lazy"

--- a/components/features/FeatureDetailsSection.vue
+++ b/components/features/FeatureDetailsSection.vue
@@ -8,9 +8,12 @@
       <div v-for="item in itemList" :key="item.id" class="col-md-6 my-3">
         <div class="px-4">
           <nuxt-img
-            :src="item.cardImage?.imageUrl || item.cardImage?.image?.url"
+            v-if="cardImg(item).src"
+            :src="cardImg(item).src"
+            :alt="cardImg(item).alt || item.title || 'Feature image'"
+            :width="cardImg(item).width || 600"
+            :height="cardImg(item).height || 400"
             class="img-fluid"
-            :alt="item.cardImage?.imageAlt || item.title || 'Feature image'"
             loading="lazy"
           />
           <h3 class="feature__heading">{{ item.title }}</h3>
@@ -29,6 +32,7 @@
 
 <script>
 import MarkdownContent from '~/components/MarkdownContent.vue'
+import { getStrapiImage } from '@/utils/strapiImage'
 
 export default {
   components: { MarkdownContent },
@@ -46,6 +50,11 @@ export default {
       required: true,
     },
   },
+  methods: {
+    cardImg(item) {
+      return getStrapiImage(item.cardImage)
+    }
+  }
 }
 </script>
 

--- a/components/features/FeatureShowcase.vue
+++ b/components/features/FeatureShowcase.vue
@@ -22,24 +22,25 @@
           <div
             class="card-image col-12 col-lg-7 d-lg-flex"
             :class="{ 'justify-content-lg-end  pe-xxl-4': !isOdd(index) }"
-            v-if="item.cardImage.image?.url || item.cardImage.imageUrl"
+            v-if="cardImg(item).src"
           >
             <nuxt-img
-              v-if="
-                !isGif(item.cardImage.image?.url || item.cardImage.imageUrl)
-              "
-              :src="item.cardImage?.image?.url || item.cardImage.imageUrl"
+              v-if="!isGif(cardImg(item).src)"
+              :src="cardImg(item).src"
+              :alt="cardImg(item).alt || item.title || 'Feature image'"
+              :width="cardImg(item).width || 800"
+              :height="cardImg(item).height || 600"
               class="img-fluid"
-              :alt="item.cardImage?.imageAlt || item.title || 'Feature image'"
               :modifiers="{ animated: true }"
               loading="lazy"
             />
             <img
               v-else
-              :src="item.cardImage?.image?.url || item.cardImage?.imageUrl"
+              :src="cardImg(item).src"
+              :alt="cardImg(item).alt || item.title || 'Feature image'"
+              :width="cardImg(item).width || 800"
+              :height="cardImg(item).height || 600"
               class="img-fluid"
-              :alt="item.cardImage?.imageAlt || item.title || 'Feature image'"
-              :modifiers="{ animated: true }"
               loading="lazy"
             />
           </div>
@@ -51,6 +52,7 @@
 
 <script>
 import MarkdownContent from '~/components/MarkdownContent.vue'
+import { getStrapiImage } from '@/utils/strapiImage'
 
 export default {
   components: { MarkdownContent },
@@ -78,6 +80,9 @@ export default {
     },
     isGif(url) {
       return url?.endsWith('.gif')
+    },
+    cardImg(item) {
+      return getStrapiImage(item.cardImage)
     },
   },
 }

--- a/components/features/SimpleStepsCreate.vue
+++ b/components/features/SimpleStepsCreate.vue
@@ -24,13 +24,15 @@
             </p>
           </div>
           <div
-            v-if="item.cardImage.image?.url || item.cardImage.imageUrl"
+            v-if="cardImg(item).src"
             class="d-flex flex-column flex-lg-row"
           >
             <nuxt-img
-              :src="item.cardImage?.image?.url || item.cardImage?.imageUrl"
+              :src="cardImg(item).src"
+              :alt="cardImg(item).alt || item?.title || 'Step image'"
+              :width="cardImg(item).width || 400"
+              :height="cardImg(item).height || 300"
               class="img-fluid my-auto"
-              :alt="item.cardImage?.imageAlt || item?.title || 'Step image'"
               loading="lazy"
             />
           </div>
@@ -42,6 +44,7 @@
 
 <script>
 import MarkdownContent from '~/components/MarkdownContent.vue'
+import { getStrapiImage } from '@/utils/strapiImage'
 
 export default {
   components: { MarkdownContent },
@@ -58,6 +61,11 @@ export default {
       type: Array,
       required: true,
     },
+  },
+  methods: {
+    cardImg(item) {
+      return getStrapiImage(item.cardImage)
+    }
   },
   computed: {
     columnClass() {

--- a/components/features/SimpleStepsCreateLg.vue
+++ b/components/features/SimpleStepsCreateLg.vue
@@ -42,14 +42,13 @@
                 />
                 <span v-else class="step__description"> {{ item?.description }}</span>
               </div>
-              <div
-                class="col-lg-5 m-auto"
-                v-if="item.cardImage?.image?.url || item.cardImage?.imageUrl"
-              >
+              <div class="col-lg-5 m-auto" v-if="cardImg(item).src">
                 <nuxt-img
-                  :src="item.cardImage.image?.url || item.cardImage.imageUrl"
+                  :src="cardImg(item).src"
+                  :alt="cardImg(item).alt || item?.title || 'Step image'"
+                  :width="cardImg(item).width || 480"
+                  :height="cardImg(item).height || 360"
                   class="w-lg-40 d-block img-fluid my-auto"
-                  :alt="item.cardImage?.imageAlt || item?.title || 'Step image'"
                   loading="lazy"
                 />
               </div>
@@ -63,6 +62,7 @@
 
 <script>
 import MarkdownContent from '~/components/MarkdownContent.vue'
+import { getStrapiImage } from '@/utils/strapiImage'
 
 export default {
   components: { MarkdownContent },
@@ -80,6 +80,11 @@ export default {
       required: true,
     },
   },
+  methods: {
+    cardImg(item) {
+      return getStrapiImage(item.cardImage)
+    }
+  }
 }
 </script>
 

--- a/components/features/StandoutFeatureDetail.vue
+++ b/components/features/StandoutFeatureDetail.vue
@@ -10,9 +10,12 @@
           class="border-sm-none border-start ps-3 d-flex flex-column align-items-start"
         >
           <nuxt-img
-            :src="item.cardImage?.image?.url || item.cardImage?.imageUrl"
+            v-if="cardImg(item).src"
+            :src="cardImg(item).src"
+            :alt="cardImg(item).alt || item.title || 'Feature image'"
+            :width="cardImg(item).width || 400"
+            :height="cardImg(item).height || 300"
             class="img-fluid"
-            :alt="item.cardImage?.imageAlt || item.title || 'Feature image'"
             loading="lazy"
           />
           <h3 class="sub__section-heading mt-4">{{ item.title }}</h3>
@@ -30,6 +33,7 @@
 
 <script>
 import MarkdownContent from '~/components/MarkdownContent.vue'
+import { getStrapiImage } from '@/utils/strapiImage'
 
 export default {
   components: { MarkdownContent },
@@ -45,6 +49,11 @@ export default {
     itemList: {
       type: Array,
       required: true,
+    },
+  },
+  methods: {
+    cardImg(item) {
+      return getStrapiImage(item.cardImage)
     },
   },
   computed: {

--- a/components/features/ThreeColBenefits.vue
+++ b/components/features/ThreeColBenefits.vue
@@ -16,9 +16,12 @@
           class="d-flex flex-column align-items-center align-items-md-start text-center text-md-start px-4 col-md-4 my-3 mt-lg-5"
         >
           <nuxt-img
+            v-if="cardImg(item).src"
             style="width: 69px"
-            :src="item.cardImage?.image?.url || item.cardImage?.imageUrl"
-            :alt="item.cardImage?.imageAlt || item?.title || 'Feature icon'"
+            :src="cardImg(item).src"
+            :alt="cardImg(item).alt || item?.title || 'Feature icon'"
+            :width="cardImg(item).width || 69"
+            :height="cardImg(item).height || 69"
             loading="lazy"
           />
           <h3 class="sub__section-heading mt-4">{{ item?.title }}</h3>
@@ -39,6 +42,7 @@
 
 <script>
 import MarkdownContent from '~/components/MarkdownContent.vue'
+import { getStrapiImage } from '@/utils/strapiImage'
 
 export default {
   components: { MarkdownContent },
@@ -56,6 +60,11 @@ export default {
       required: true,
     },
   },
+  methods: {
+    cardImg(item) {
+      return getStrapiImage(item.cardImage)
+    }
+  }
 }
 </script>
 

--- a/components/features/TwoColBenefits.vue
+++ b/components/features/TwoColBenefits.vue
@@ -11,10 +11,13 @@
             class="card p-3 d-flex align-items-center justify-items-center text-center align-items-md-start text-md-start"
           >
             <nuxt-img
-              :src="item.cardImage.image?.url || item.cardImage.imageUrl"
+              v-if="cardImg(item).src"
+              :src="cardImg(item).src"
+              :alt="cardImg(item).alt || item.title || 'Feature icon'"
+              :width="cardImg(item).width || 69"
+              :height="cardImg(item).height || 69"
               class="img-fluid"
               style="width: 69px"
-              :alt="item.cardImage?.imageAlt || item.title || 'Feature icon'"
               loading="lazy"
             />
             <h3 class="sub__section-heading mt-4">{{ item.title }}</h3>
@@ -33,6 +36,7 @@
 
 <script>
 import MarkdownContent from '~/components/MarkdownContent.vue'
+import { getStrapiImage } from '@/utils/strapiImage'
 
 export default {
   components: { MarkdownContent },
@@ -50,6 +54,11 @@ export default {
       required: true,
     },
   },
+  methods: {
+    cardImg(item) {
+      return getStrapiImage(item.cardImage)
+    }
+  }
 }
 </script>
 

--- a/components/home/HeroTabShowcase/HeroTabs.vue
+++ b/components/home/HeroTabShowcase/HeroTabs.vue
@@ -27,11 +27,11 @@
               <li v-for="(feature, i) in tab.features" :key="i">
                 <span class="feature-icon">
                   <img
-                    :src="feature.icon"
+                    :src="feature.icon.src"
                     :alt="feature.text + ' icon'"
                     class="feature-icon"
-                    width="20"
-                    height="20"
+                    :width="feature.icon.width || 20"
+                    :height="feature.icon.height || 20"
                     loading="lazy"
                   />
                 </span>
@@ -41,11 +41,12 @@
           </div>
           <div class="tab-right">
             <img
-              :src="tab.image"
+              :src="tab.image.src"
               :alt="tab.label + ' screenshot'"
               class="tab-image"
               :loading="idx === 0 ? 'eager' : 'lazy'"
-              width="480"
+              :width="tab.image.width || 480"
+              :height="tab.image.height || 360"
             />
           </div>
         </div>
@@ -56,6 +57,7 @@
 
 <script setup>
 import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { getStrapiImage } from '@/utils/strapiImage'
 
 // Define props to receive Strapi data
 const props = defineProps({
@@ -75,15 +77,12 @@ const borderColors = [
 ]
 
 
-const getImageUrl = (imageObj) => {
-  if (!imageObj) return null
-  
-  if (imageObj.imageUrl) return imageObj.imageUrl
-  
-  if (imageObj.image?.url) return imageObj.image.url
-  
-  return null
-}
+// Fallback tab images live under /public; provide their natural dimensions
+// so the static fallback path also gets width/height attributes set.
+const fallbackImageDims = { width: 1200, height: 800 }
+const fallbackIconDims = { width: 20, height: 20 }
+
+const wrapStaticImage = (src, dims) => ({ src, width: dims.width, height: dims.height })
 
 const fallbackTabs = [
 {
@@ -201,17 +200,21 @@ const fallbackTabs = [
 
 const tabs = computed(() => {
   if (!props.data?.tabCardContent || props.data.tabCardContent.length === 0) {
-    return fallbackTabs
+    return fallbackTabs.map(tab => ({
+      ...tab,
+      features: tab.features.map(f => ({ ...f, icon: wrapStaticImage(f.icon, fallbackIconDims) })),
+      image: wrapStaticImage(tab.image, fallbackImageDims),
+    }))
   }
-  
+
   return props.data.tabCardContent.map(tab => ({
     label: tab.navTitle,
     title: tab.title,
     features: tab.feature?.map(feature => ({
       text: feature.featureTitle,
-      icon: getImageUrl(feature.icon)
+      icon: getStrapiImage(feature.icon, { width: fallbackIconDims.width, height: fallbackIconDims.height }),
     })) || [],
-    image: getImageUrl(tab.image)
+    image: getStrapiImage(tab.image, { width: fallbackImageDims.width, height: fallbackImageDims.height }),
   }))
 })
 

--- a/components/home/HeroTabShowcase/HeroTabs.vue
+++ b/components/home/HeroTabShowcase/HeroTabs.vue
@@ -25,7 +25,7 @@
             <h3 class="tab-title">{{ tab.title }}</h3>
             <ul class="tab-features">
               <li v-for="(feature, i) in tab.features" :key="i">
-                <span class="feature-icon">
+                <span class="feature-icon" v-if="feature.icon?.src">
                   <img
                     :src="feature.icon.src"
                     :alt="feature.text + ' icon'"
@@ -39,7 +39,7 @@
               </li>
             </ul>
           </div>
-          <div class="tab-right">
+          <div class="tab-right" v-if="tab.image?.src">
             <img
               :src="tab.image.src"
               :alt="tab.label + ' screenshot'"

--- a/components/home/MostUsedFeatures.vue
+++ b/components/home/MostUsedFeatures.vue
@@ -26,8 +26,11 @@
               ]"
             >
               <nuxt-img
-                :src="feature.icon?.imageUrl || feature.icon?.image?.url"
-                :alt="feature.icon?.imageAlt || feature.title || 'Feature icon'"
+                v-if="featureIcon(feature).src"
+                :src="featureIcon(feature).src"
+                :alt="featureIcon(feature).alt || feature.title || 'Feature icon'"
+                :width="featureIcon(feature).width || 32"
+                :height="featureIcon(feature).height || 32"
                 loading="lazy"
                 :class="{ 'grey-filter': activeIndex !== index }"
               />
@@ -76,9 +79,11 @@
         <transition name="fade" mode="out-in">
           <nuxt-img
             class="feature__img img-fluid"
-            :src="activeFeatureImageUrl"
-            :alt="activeFeatureImageAlt"
-            :key="activeFeatureImageUrl"
+            :src="activeFeature.src"
+            :alt="activeFeature.alt"
+            :width="activeFeature.width || 600"
+            :height="activeFeature.height || 400"
+            :key="activeFeature.src"
             sizes="sm:100vw md:50vw lg:600px"
           />
         </transition>
@@ -88,8 +93,11 @@
     <div class="d-lg-none">
       <div v-for="feature in itemList" :key="feature.title" class="mt-5">
         <nuxt-img
-          :src="feature.cardImage?.imageUrl || feature.cardImage?.image?.url"
-          :alt="feature.cardImage?.imageAlt || feature.title || 'Feature image'"
+          v-if="cardImg(feature).src"
+          :src="cardImg(feature).src"
+          :alt="cardImg(feature).alt || feature.title || 'Feature image'"
+          :width="cardImg(feature).width || 600"
+          :height="cardImg(feature).height || 400"
           class="mb-4 img-fluid"
           loading="lazy"
           sizes="10vw"
@@ -99,8 +107,11 @@
             class="feature__icon-wrapper d-flex align-items-center justify-content-center"
           >
             <nuxt-img
-              :src="feature.icon?.imageUrl || feature.icon?.image?.url"
-              :alt="feature.icon?.imageAlt || feature.title || 'Feature icon'"
+              v-if="featureIcon(feature).src"
+              :src="featureIcon(feature).src"
+              :alt="featureIcon(feature).alt || feature.title || 'Feature icon'"
+              :width="featureIcon(feature).width || 32"
+              :height="featureIcon(feature).height || 32"
               loading="lazy"
             />
           </div>
@@ -123,6 +134,7 @@
 
 <script>
 import MarkdownContent from '~/components/MarkdownContent.vue'
+import { getStrapiImage } from '@/utils/strapiImage'
 
 export default {
   components: { MarkdownContent },
@@ -152,17 +164,18 @@ export default {
     this.stopAutoRotation()
   },
   computed: {
-    activeFeatureImageUrl() {
-      return (
-        this.itemList[this.activeIndex].cardImage.imageUrl ||
-        this.itemList[this.activeIndex].cardImage.image.url
-      )
-    },
-    activeFeatureImageAlt() {
-      return this.itemList[this.activeIndex].cardImage?.imageAlt
+    activeFeature() {
+      const item = this.itemList[this.activeIndex] || {}
+      return getStrapiImage(item.cardImage, { alt: item.title })
     },
   },
   methods: {
+    cardImg(feature) {
+      return getStrapiImage(feature.cardImage)
+    },
+    featureIcon(feature) {
+      return getStrapiImage(feature.icon)
+    },
     handleFeatureClick(index) {
       this.activeIndex = index
       // Reset auto-rotation when manually clicking

--- a/components/home/TestimonialCard.vue
+++ b/components/home/TestimonialCard.vue
@@ -5,14 +5,19 @@
         src="/UI Block/quotation.svg"
         class="quotation-marks mb-2"
         alt="Quotation marks"
+        width="30"
+        height="30"
         loading="lazy"
       />
       <p class="mt-1">{{ testimonial.comment }}</p>
     </div>
     <div class="d-flex">
       <nuxt-img
-        :src="getIconSrc(testimonial.profileImage)"
-        :alt="testimonial?.profileImage?.imageAlt || 'User profile'"
+        v-if="profileImg.src"
+        :src="profileImg.src"
+        :alt="profileImg.alt || 'User profile'"
+        :width="profileImg.width || 48"
+        :height="profileImg.height || 48"
         class="img-fluid testimonial__user"
         loading="lazy"
       />
@@ -28,6 +33,8 @@
 </template>
 
 <script>
+import { getStrapiImage } from '@/utils/strapiImage'
+
 export default {
   props: {
     testimonial: {
@@ -35,35 +42,9 @@ export default {
       required: true
     }
   },
-  methods: {
-    getIconSrc(iconObject) {
-      if (!iconObject) return '';
-
-      // Handle different Strapi image structures
-      if (iconObject.imageUrl) {
-        return iconObject.imageUrl;
-      }
-
-      if (iconObject.image) {
-        if (iconObject.image.url) {
-          return iconObject.image.url;
-        }
-
-        if (iconObject.image.data) {
-          if (iconObject.image.data.attributes && iconObject.image.data.attributes.url) {
-            return iconObject.image.data.attributes.url;
-          }
-
-          if (Array.isArray(iconObject.image.data) &&
-              iconObject.image.data[0] &&
-              iconObject.image.data[0].attributes &&
-              iconObject.image.data[0].attributes.url) {
-            return iconObject.image.data[0].attributes.url;
-          }
-        }
-      }
-
-      return '';
+  computed: {
+    profileImg() {
+      return getStrapiImage(this.testimonial?.profileImage)
     }
   }
 }

--- a/components/home/Testimonials.vue
+++ b/components/home/Testimonials.vue
@@ -18,6 +18,8 @@
               class="quotes__logo"
               src="/quotes.svg"
               alt="Quote icon"
+              width="81"
+              height="63"
               loading="lazy"
             />
             <div class="d-flex flex-column align-items-center text-center px-2">
@@ -26,9 +28,12 @@
                 <span class="person">{{ testimonial.name }}</span>
                 <span class="designation">{{ testimonial.position }}</span>
                 <nuxt-img
+                  v-if="getCompanyLogo(testimonial).src"
                   class="brand mt-4 mb-3"
-                  :src="getIconSrc(testimonial.companyLogo)"
-                  :alt="testimonial?.companyLogo?.imageAlt || `${testimonial.name}'s company logo`"
+                  :src="getCompanyLogo(testimonial).src"
+                  :alt="getCompanyLogo(testimonial).alt || `${testimonial.name}'s company logo`"
+                  :width="getCompanyLogo(testimonial).width || 110"
+                  :height="getCompanyLogo(testimonial).height || 36"
                   loading="lazy"
                 />
               </div>
@@ -41,7 +46,7 @@
     <!-- Homepage Testimonials Layout with Auto-Scrolling Ticker for Desktop / Carousel for Mobile -->
     <div class="my-5 py-5" v-else>
       <div class="icon-wrapper">
-        <img src="/assets/images/TestimonialSection.svg" alt="Quote icon" />
+        <img src="/assets/images/TestimonialSection.svg" alt="Quote icon" width="40" height="40" />
         <p class="tag">USER TESTIMONIALS</p>
       </div>
       <SectionTitle :heading="heading" />
@@ -97,6 +102,7 @@
 
 <script>
 import TestimonialCard from './TestimonialCard.vue'
+import { getStrapiImage } from '@/utils/strapiImage'
 
 export default {
   components: {
@@ -317,39 +323,8 @@ export default {
       document.addEventListener('touchend', this.handleDragEnd)
     },
 
-    getIconSrc(iconObject) {
-      if (!iconObject) return ''
-
-      // Handle different Strapi image structures
-      if (iconObject.imageUrl) {
-        return iconObject.imageUrl
-      }
-
-      if (iconObject.image) {
-        if (iconObject.image.url) {
-          return iconObject.image.url
-        }
-
-        if (iconObject.image.data) {
-          if (
-            iconObject.image.data.attributes &&
-            iconObject.image.data.attributes.url
-          ) {
-            return iconObject.image.data.attributes.url
-          }
-
-          if (
-            Array.isArray(iconObject.image.data) &&
-            iconObject.image.data[0] &&
-            iconObject.image.data[0].attributes &&
-            iconObject.image.data[0].attributes.url
-          ) {
-            return iconObject.image.data[0].attributes.url
-          }
-        }
-      }
-
-      return ''
+    getCompanyLogo(testimonial) {
+      return getStrapiImage(testimonial?.companyLogo)
     },
     handleDragStart(e) {
       e.preventDefault()

--- a/components/home/TrustSeals.vue
+++ b/components/home/TrustSeals.vue
@@ -21,28 +21,29 @@
               class="ticker-content"
             >
               <div class="ticker-item">
-                <nuxt-img src="/trustseals/01.svg" alt="Peabody" height="40" />
+                <nuxt-img src="/trustseals/01.svg" alt="Peabody" width="118" height="40" />
               </div>
               <div class="ticker-item">
-                <nuxt-img src="/trustseals/02.svg" alt="Aramark" height="40" />
+                <nuxt-img src="/trustseals/02.svg" alt="Aramark" width="142" height="40" />
               </div>
               <div class="ticker-item">
-                <nuxt-img src="/trustseals/03.svg" alt="Loreal" height="32" />
+                <nuxt-img src="/trustseals/03.svg" alt="Loreal" width="177" height="32" />
               </div>
               <div class="ticker-item">
-                <nuxt-img src="/trustseals/04.svg" alt="Toptal" height="40" />
+                <nuxt-img src="/trustseals/04.svg" alt="Toptal" width="131" height="40" />
               </div>
 
               <div class="ticker-item">
-                <nuxt-img src="/trustseals/05.svg" alt="Grab" height="38" />
+                <nuxt-img src="/trustseals/05.svg" alt="Grab" width="108" height="38" />
               </div>
               <div class="ticker-item">
-                <nuxt-img src="/trustseals/06.svg" alt="SFU" height="36" />
+                <nuxt-img src="/trustseals/06.svg" alt="SFU" width="154" height="36" />
               </div>
               <div class="ticker-item">
                 <nuxt-img
                   src="/trustseals/07.svg"
                   alt="World of Hyatt"
+                  width="321"
                   height="32"
                 />
               </div>
@@ -50,6 +51,7 @@
                 <nuxt-img
                   src="/trustseals/08.svg"
                   alt="Iolani School"
+                  width="225"
                   height="40"
                 />
               </div>
@@ -57,14 +59,16 @@
                 <nuxt-img
                   src="/trustseals/09.svg"
                   alt="Austin Independent School District"
+                  width="146"
                   height="44"
                 />
               </div>
               <div class="ticker-item">
-                <nuxt-img 
-                src="/trustseals/10.svg" 
-                alt="Virgin" 
-                height="64" 
+                <nuxt-img
+                src="/trustseals/10.svg"
+                alt="Virgin"
+                width="73"
+                height="64"
                 />
               </div>
             </div>

--- a/components/home/Usecases/UsecaseCard.vue
+++ b/components/home/Usecases/UsecaseCard.vue
@@ -1,7 +1,13 @@
 <template>
   <div class="usecase-card">
-    <div class="image-wrapper" v-if="computedImage">
-      <img :src="computedImage" :alt="title" width="100%" height="100%" class="img-fluid"/>
+    <div class="image-wrapper" v-if="img.src">
+      <img
+        :src="img.src"
+        :alt="img.alt || title"
+        :width="img.width || 400"
+        :height="img.height || 160"
+        class="img-fluid"
+      />
     </div>
     <div class="content">
       <h3 class="title">{{ title }}</h3>
@@ -12,6 +18,8 @@
 </template>
 
 <script>
+import { getStrapiImage } from '@/utils/strapiImage'
+
 export default {
   name: 'UsecaseCard',
   props: {
@@ -20,15 +28,17 @@ export default {
     image: { type: [String, Object], default: null }
   },
   computed: {
-    computedImage() {
-      if (!this.image) return null;
-      if (typeof this.image === 'string') return this.image;
-      if (this.image.formats) {
-        if (this.image.formats.medium) return this.image.formats.medium.url;
-        if (this.image.formats.small) return this.image.formats.small.url;
-        if (this.image.formats.thumbnail) return this.image.formats.thumbnail.url;
+    img() {
+      if (typeof this.image === 'string') {
+        return { src: this.image, alt: this.title, width: null, height: null }
       }
-      return this.image.url;
+      // Prefer the medium format if available — it's what was being used before.
+      const media = this.image?.data?.attributes || this.image
+      if (media?.formats?.medium) {
+        const m = media.formats.medium
+        return { src: m.url, alt: media.alternativeText || this.title, width: m.width, height: m.height }
+      }
+      return getStrapiImage(this.image, { alt: this.title })
     }
   }
 }

--- a/components/integrations/IntegrationCard.vue
+++ b/components/integrations/IntegrationCard.vue
@@ -9,9 +9,12 @@
       <div class="icon-wrapper">
         <div class="icon-glow"></div>
         <nuxt-img
-          :src="getImgUrl(app)"
-          :alt="app.name"
+          :src="appImg.src"
+          :alt="appImg.alt || app.name"
+          :width="appImg.width || 32"
+          :height="appImg.height || 32"
           class="app-icon"
+          loading="lazy"
         />
       </div>
 
@@ -24,21 +27,25 @@
 </template>
 
 <script>
+import { getStrapiImage } from '@/utils/strapiImage'
+
 export default {
   props: ['app'],
+  computed: {
+    appImg() {
+      const fromIcon = getStrapiImage(this.app.icon, { alt: this.app.name })
+      if (fromIcon.src) return fromIcon
+      if (this.app.image || this.app.imageUrl) {
+        const fromImage = getStrapiImage(this.app.image || this.app, { alt: this.app.name })
+        if (fromImage.src) return fromImage
+      }
+      if (this.app.img) {
+        return { src: `/integrations/${this.app.img}`, alt: this.app.name, width: null, height: null }
+      }
+      return { src: '', alt: this.app.name, width: null, height: null }
+    }
+  },
   methods: {
-    getImgUrl(app) {
-      if (app.icon?.image?.url || app.icon?.imageUrl) {
-        return app.icon.image?.url || app.icon.imageUrl
-      }
-      if (app.image?.url || app.imageUrl) {
-        return app.image?.url || app.imageUrl
-      }
-      if (app.img) {
-        return `/integrations/${app.img}`
-      }
-      return ''
-    },
     getLink(app) {
       return app.url || app.helpArticle || app.link
     }

--- a/components/nav/DropdownItem.vue
+++ b/components/nav/DropdownItem.vue
@@ -4,7 +4,7 @@
     :to="`/features/${slug}/`"
     @click="collapseNav"
   >
-    <nuxt-img :src="imageUrl" :alt="imageAlt" class="dropdown-item__img" />
+    <nuxt-img v-if="imageUrl" :src="imageUrl" :alt="imageAlt" class="dropdown-item__img" width="24" height="24" loading="lazy" />
     <div class="d-flex flex-column">
       <div class="d-flex align-items-center gap-2">
         <span class="dropdown-item__title">{{ title }}</span>
@@ -13,10 +13,12 @@
           class="plan-icon-wrapper" 
           title="Available in Business Plan"
         >
-          <img 
-            src="/assets/images/business.svg" 
+          <img
+            src="/assets/images/business.svg"
             alt="Business plan"
             class="plan-icon"
+            width="20"
+            height="20"
           />
         </div>
         <div 
@@ -24,10 +26,12 @@
           class="plan-icon-wrapper" 
           title="Available in Personal Plan"
         >
-          <img 
-            src="/assets/images/personal.svg" 
+          <img
+            src="/assets/images/personal.svg"
             alt="Personal plan"
             class="plan-icon"
+            width="20"
+            height="20"
           />
         </div>
       </div>
@@ -49,11 +53,11 @@ export default {
     },
     imageUrl: {
       type: String,
-      required: true,
+      default: null,
     },
     imageAlt: {
       type: String,
-      required: true,
+      default: '',
     },
     slug: {
       type: String,

--- a/components/nav/Navbar.vue
+++ b/components/nav/Navbar.vue
@@ -4,7 +4,7 @@
       <div class="container d-flex align-items-center">
         <!-- Logo -->
         <NuxtLink class="navbar-brand-wrapper" to="/">
-          <nuxt-img class="navbar-brand" src="/logo.svg" alt="Formester" />
+          <nuxt-img class="navbar-brand" src="/logo.svg" alt="Formester" width="175" height="24" />
         </NuxtLink>
 
         <!-- Mobile Toggle Button -->
@@ -18,7 +18,7 @@
           aria-label="Toggle navigation"
           @click="toggleNav"
         >
-          <nuxt-img src="/toggle.svg" alt="Nav-menu-button" />
+          <nuxt-img src="/toggle.svg" alt="Nav-menu-button" width="24" height="24" />
         </button>
 
         <!-- Navigation Menu -->
@@ -51,11 +51,16 @@
                       src="/chevron-down-gray.svg"
                       class="chevron chevron-gray"
                       alt="Chevron"
+                      width="24"
+                      height="24"
                       :class="{ open: dropdownActive }"
                     />
                     <nuxt-img
                       src="/chevron-down-colored.svg"
                       class="chevron chevron-colored"
+                      alt=""
+                      width="24"
+                      height="24"
                       :class="{ open: dropdownActive }"
                     />
                   </span>
@@ -78,11 +83,16 @@
                       src="/chevron-down-gray.svg"
                       class="chevron chevron-gray"
                       alt="Chevron"
+                      width="24"
+                      height="24"
                       :class="{ open: dropdownActive }"
                     />
                     <nuxt-img
                       src="/chevron-down-colored.svg"
                       class="chevron chevron-colored"
+                      alt=""
+                      width="24"
+                      height="24"
                       :class="{ open: dropdownActive }"
                     />
                   </span>

--- a/components/nav/ResourcesDropdown.vue
+++ b/components/nav/ResourcesDropdown.vue
@@ -28,9 +28,13 @@
                 @click="collapseNav"
               >
                 <nuxt-img
-                  :src="resource?.imageUrl"
-                  :alt="resource?.imageAlt"
+                  v-if="resource?.imageUrl"
+                  :src="resource.imageUrl"
+                  :alt="resource?.imageAlt || ''"
                   class="resource-dropdown-item__img"
+                  width="24"
+                  height="24"
+                  loading="lazy"
                 />
                 <div class="d-flex flex-column">
                   <span class="resource-dropdown-item__title">{{

--- a/components/strapi/HeroCenteredDark.vue
+++ b/components/strapi/HeroCenteredDark.vue
@@ -42,7 +42,7 @@
             :key="item"
             class="d-flex align-items-center justify-content-center mx-4"
           >
-            <nuxt-img src="/icons/check-icon.svg" alt="tick" />
+            <nuxt-img src="/icons/check-icon.svg" alt="tick" width="20" height="20" />
             <span class="click-triggers ms-2">{{ item.text }}</span>
           </div>
         </div>

--- a/components/strapi/HeroCenteredDark.vue
+++ b/components/strapi/HeroCenteredDark.vue
@@ -2,7 +2,7 @@
   <section
     class="hero"
     :style="{
-      backgroundImage: background.image?.url
+      backgroundImage: background?.image?.url
         ? `url(${background.image.url})`
         : '',
     }"

--- a/components/strapi/IntegrationCard.vue
+++ b/components/strapi/IntegrationCard.vue
@@ -7,6 +7,9 @@
         :src="tool.icon"
         :alt="tool.name"
         class="tool-icon"
+        width="48"
+        height="48"
+        loading="lazy"
       />
     </div>
     <div class="action">{{ action }}</div>

--- a/components/strapi/IntegrationCard.vue
+++ b/components/strapi/IntegrationCard.vue
@@ -1,16 +1,17 @@
 <template>
   <div class="integration-card">
     <div class="tools-container">
-      <img
-        v-for="tool in tools"
-        :key="tool.name"
-        :src="tool.icon"
-        :alt="tool.name"
-        class="tool-icon"
-        width="48"
-        height="48"
-        loading="lazy"
-      />
+      <template v-for="tool in tools" :key="tool.name">
+        <img
+          v-if="tool.icon"
+          :src="tool.icon"
+          :alt="tool.name"
+          class="tool-icon"
+          width="48"
+          height="48"
+          loading="lazy"
+        />
+      </template>
     </div>
     <div class="action">{{ action }}</div>
   </div>

--- a/components/strapi/Trustbadges.vue
+++ b/components/strapi/Trustbadges.vue
@@ -4,44 +4,26 @@
       <SectionTitle :heading="title" />
       <p>{{ description }}</p>
       <div class="trustbadge-wrapper">
-        <div class="rating-wrapper">
-          <nuxt-img src="/product-hunt.svg" alt="Product Hunt" class="logo" width="171" height="40" />
+        <div
+          v-for="(badge, i) in badges"
+          :key="badge.id || i"
+          class="rating-wrapper"
+        >
+          <nuxt-img
+            :src="logoFor(badge).src"
+            :alt="logoFor(badge).alt"
+            :width="logoFor(badge).width"
+            :height="logoFor(badge).height"
+            class="logo"
+          />
           <div class="rating">
-            <span class="rating-number">5/5</span>
-            <nuxt-img src="/5-stars.svg" alt="5 stars" class="rating-stars" width="139" height="24" />
-          </div>
-        </div>
-        <div class="rating-wrapper">
-          <nuxt-img src="/trustpilot.svg" alt="Trustpilot" class="logo" width="163" height="40" />
-          <div class="rating">
-            <span class="rating-number">4.4/5</span>
+            <span class="rating-number">{{ badge.ratingNumber }}</span>
             <nuxt-img
-              src="/4.5-stars.svg"
-              alt="4.5 stars"
+              :src="starsFor(badge).src"
+              :alt="starsFor(badge).alt"
+              :width="starsFor(badge).width"
+              :height="starsFor(badge).height"
               class="rating-stars"
-              width="139"
-              height="24"
-            />
-          </div>
-        </div>
-        <div class="rating-wrapper">
-          <nuxt-img src="/capterra.svg" alt="Capterra" class="logo" width="174" height="40" />
-          <div class="rating">
-            <span class="rating-number">5/5</span>
-            <nuxt-img src="/5-stars.svg" alt="5 stars" class="rating-stars" width="139" height="24" />
-          </div>
-        </div>
-
-        <div class="rating-wrapper">
-          <nuxt-img src="/g2-crowd.svg" alt="G2 Crowd" class="logo" width="40" height="40" />
-          <div class="rating">
-            <span class="rating-number">4.7/5</span>
-            <nuxt-img
-              src="/4.5-stars.svg"
-              alt="4.5 stars"
-              class="rating-stars"
-              width="139"
-              height="24"
             />
           </div>
         </div>
@@ -51,6 +33,8 @@
 </template>
 
 <script>
+import { getStrapiImage } from '@/utils/strapiImage'
+
 export default {
   props: {
     title: {
@@ -59,6 +43,18 @@ export default {
     },
     description: {
       type: String,
+    },
+    badges: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  methods: {
+    logoFor(badge) {
+      return getStrapiImage(badge?.logo)
+    },
+    starsFor(badge) {
+      return getStrapiImage(badge?.stars)
     },
   },
 }

--- a/components/strapi/Trustbadges.vue
+++ b/components/strapi/Trustbadges.vue
@@ -5,39 +5,43 @@
       <p>{{ description }}</p>
       <div class="trustbadge-wrapper">
         <div class="rating-wrapper">
-          <nuxt-img src="/product-hunt.svg" alt="Product Hunt" class="logo" />
+          <nuxt-img src="/product-hunt.svg" alt="Product Hunt" class="logo" width="171" height="40" />
           <div class="rating">
             <span class="rating-number">5/5</span>
-            <nuxt-img src="/5-stars.svg" alt="5 stars" class="rating-stars" />
+            <nuxt-img src="/5-stars.svg" alt="5 stars" class="rating-stars" width="139" height="24" />
           </div>
         </div>
         <div class="rating-wrapper">
-          <nuxt-img src="/trustpilot.svg" alt="Trustpilot" class="logo" />
+          <nuxt-img src="/trustpilot.svg" alt="Trustpilot" class="logo" width="163" height="40" />
           <div class="rating">
             <span class="rating-number">4.4/5</span>
             <nuxt-img
               src="/4.5-stars.svg"
               alt="4.5 stars"
               class="rating-stars"
+              width="139"
+              height="24"
             />
           </div>
         </div>
         <div class="rating-wrapper">
-          <nuxt-img src="/capterra.svg" alt="Capterra" class="logo" />
+          <nuxt-img src="/capterra.svg" alt="Capterra" class="logo" width="174" height="40" />
           <div class="rating">
             <span class="rating-number">5/5</span>
-            <nuxt-img src="/5-stars.svg" alt="5 stars" class="rating-stars" />
+            <nuxt-img src="/5-stars.svg" alt="5 stars" class="rating-stars" width="139" height="24" />
           </div>
         </div>
 
         <div class="rating-wrapper">
-          <nuxt-img src="/g2-crowd.svg" alt="G2 Crowd" class="logo" />
+          <nuxt-img src="/g2-crowd.svg" alt="G2 Crowd" class="logo" width="40" height="40" />
           <div class="rating">
             <span class="rating-number">4.7/5</span>
             <nuxt-img
               src="/4.5-stars.svg"
               alt="4.5 stars"
               class="rating-stars"
+              width="139"
+              height="24"
             />
           </div>
         </div>

--- a/components/strapi/VideoSection.vue
+++ b/components/strapi/VideoSection.vue
@@ -15,11 +15,14 @@
           <!-- YouTube Video Thumbnail with Custom Play Button -->
           <div v-if="video_url" class="video-thumbnail-wrapper" @click="showOverlay = true">
             <nuxt-img
-              :src="thumbnail ? thumbnail.url : youtubeThumbnailUrl"
+              :src="thumbImg.src || youtubeThumbnailUrl"
+              :alt="thumbImg.alt || 'Video thumbnail'"
+              :width="thumbImg.width || 800"
+              :height="thumbImg.height || 533"
               class="video-thumb-img"
             />
             <button class="custom-play-btn" aria-label="Play video">
-              <nuxt-img src="/play-button.svg" alt="Play video" />
+              <nuxt-img src="/play-button.svg" alt="Play video" width="64" height="64" />
           </button>
           </div>
           <!-- Overlay -->
@@ -34,7 +37,7 @@
                 allowfullscreen
               ></iframe>
               <button @click="closeOverlay" aria-label="Close video" class="close-btn">
-                <nuxt-img src="/x-close.svg" alt="Close video" />
+                <nuxt-img src="/x-close.svg" alt="Close video" width="24" height="24" />
               </button>
             </div>
           </div>
@@ -45,6 +48,7 @@
 
   <script>
   import MarkdownContent from '~/components/MarkdownContent.vue'
+  import { getStrapiImage } from '@/utils/strapiImage'
 
   export default {
     components: { MarkdownContent },
@@ -76,6 +80,9 @@
     };
   },
   computed: {
+    thumbImg() {
+      return getStrapiImage(this.thumbnail)
+    },
     youtubeVideoId() {
       // Extracts the video ID from various YouTube URL formats
       const url = this.video_url;

--- a/components/table/TableRow.vue
+++ b/components/table/TableRow.vue
@@ -10,6 +10,9 @@
         <img
           :src="getIconSrc(cell.cellIcon)"
           :alt="getIconAlt(cell)"
+          width="24"
+          height="24"
+          loading="lazy"
           style="max-width:24px; max-height:24px; object-fit:contain; display:block;"
         />
       </template>

--- a/components/template/TemplateCard.vue
+++ b/components/template/TemplateCard.vue
@@ -7,6 +7,9 @@
         :class="{ hidden: loading }"
         :src="previewImageUrl"
         :alt="template.name"
+        width="1200"
+        height="738"
+        loading="lazy"
         @load="loading = false"
       />
       <div class="template-content">

--- a/composables/useBlogData.js
+++ b/composables/useBlogData.js
@@ -9,12 +9,17 @@ export const useBlogData = async () => {
     try {
       const data = await getAllBlogs()
 
-      let articles = data.map((item) => ({
-        id: item.id,
-        ...item.attributes,
-        coverImg: item.attributes.coverImg?.data?.attributes?.url || '',
-        readingStats: readingTime(item.attributes.body || ''),
-      }))
+      let articles = data.map((item) => {
+        const cover = item.attributes.coverImg?.data?.attributes
+        return {
+          id: item.id,
+          ...item.attributes,
+          coverImg: cover?.url || '',
+          coverImgWidth: cover?.width || 1200,
+          coverImgHeight: cover?.height || 630,
+          readingStats: readingTime(item.attributes.body || ''),
+        }
+      })
 
       const heroArticles = articles.filter((item) => item.featured)
       articles = articles.filter((item) => !item.featured)

--- a/constants/navbar.json
+++ b/constants/navbar.json
@@ -635,5 +635,14 @@
         "alt": "message-check-square"
       }
     }
+  },
+  {
+    "id": 628,
+    "slug": "gdpr-compliant-forms",
+    "navTitle": "GDPR Compliance",
+    "navDescription": "Build GDPR compliant forms",
+    "featureCategory": "Security & Validation",
+    "featurePlan": "Free",
+    "navIcon": null
   }
 ]

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -164,10 +164,13 @@ const { data: blogResponse } = await useAsyncData(`blog-${route.params.slug}`, a
       throw createError({ statusCode: 404, message: 'Page not found' })
     }
 
+    const cover = blog.attributes.coverImg?.data?.attributes
     const blogData = {
       id: blog.id,
       ...blog.attributes,
-      coverImg: blog.attributes.coverImg?.data?.attributes?.url,
+      coverImg: cover?.url,
+      coverImgWidth: cover?.width || 1200,
+      coverImgHeight: cover?.height || 630,
       metaImage: blog.attributes.metaImage?.map((item) => item.imageURL) || [],
       readingStats: readingTime(blog.attributes.body || ''),
     }
@@ -176,12 +179,17 @@ const { data: blogResponse } = await useAsyncData(`blog-${route.params.slug}`, a
     const allBlogs = await getAllBlogs()
     const otherBlogs = allBlogs.filter((item) => item.attributes.slug !== route.params.slug)
     const shuffled = [...otherBlogs].sort(() => Math.random() - 0.5)
-    const relatedArticles = shuffled.slice(0, 4).map((item) => ({
-      ...item.attributes,
-      id: item.id,
-      coverImg: item.attributes.coverImg?.data?.attributes?.url,
-      readingStats: readingTime(item.attributes.body || ''),
-    }))
+    const relatedArticles = shuffled.slice(0, 4).map((item) => {
+      const c = item.attributes.coverImg?.data?.attributes
+      return {
+        ...item.attributes,
+        id: item.id,
+        coverImg: c?.url,
+        coverImgWidth: c?.width || 1200,
+        coverImgHeight: c?.height || 630,
+        readingStats: readingTime(item.attributes.body || ''),
+      }
+    })
 
     return { blogData, relatedArticles }
   } catch (error) {

--- a/pages/templates/[slug].vue
+++ b/pages/templates/[slug].vue
@@ -90,13 +90,21 @@
                   </svg>
                 </button>
                 <!-- Show first preview image (carousel temporarily disabled due to Vue 3 compatibility) -->
-                <img v-if="previewImages.length >= 1" :src="previewImages[0].url" :alt="previewImages[0].alt || 'Template Preview'" class="template-preview__image">
+                <img
+                  v-if="previewImages.length >= 1"
+                  :src="previewImages[0].url"
+                  :alt="previewImages[0].alt || 'Template Preview'"
+                  :width="previewImages[0].width || 1200"
+                  :height="previewImages[0].height || 738"
+                  class="template-preview__image"
+                  loading="lazy"
+                >
               </div>
 
               <!-- Fullscreen Modal Overlay -->
               <div v-if="showFullscreen" class="fullscreen-modal" @click.self="closeFullscreen">
                 <button class="modal-close" @click="closeFullscreen" aria-label="Close fullscreen">
-                  <img :src="closeIcon" alt="Close" />
+                  <img :src="closeIcon" alt="Close" width="24" height="24" />
                 </button>
                 <button v-if="previewImages.length > 1" class="modal-arrow left" @click.stop="prevModal" aria-label="Previous image">
                   <span>&lsaquo;</span>
@@ -105,6 +113,8 @@
                   v-if="previewImages.length"
                   :src="previewImages[modalIndex].url"
                   :alt="previewImages[modalIndex].alt || 'Template Preview'"
+                  :width="previewImages[modalIndex].width || 1200"
+                  :height="previewImages[modalIndex].height || 738"
                   class="fullscreen-image"
                 />
                 <button v-if="previewImages.length > 1" class="modal-arrow right" @click.stop="nextModal" aria-label="Next image">
@@ -265,20 +275,29 @@ const previewImages = computed(() => {
     // Handle different Strapi image structures
     let url = ''
     let alt = ''
+    let width = null
+    let height = null
     let id = item.id
 
     if (item.image?.url) {
       url = item.image.url
       alt = item.image.alternativeText || item.imageAlt || 'Template Preview'
+      width = item.width || item.image.width
+      height = item.height || item.image.height
     } else if (item.image?.data?.attributes?.url) {
-      url = item.image.data.attributes.url
-      alt = item.image.data.attributes.alternativeText || item.imageAlt || 'Template Preview'
+      const a = item.image.data.attributes
+      url = a.url
+      alt = a.alternativeText || item.imageAlt || 'Template Preview'
+      width = item.width || a.width
+      height = item.height || a.height
     } else if (item.imageUrl) {
       url = item.imageUrl
       alt = item.imageAlt || 'Template Preview'
+      width = item.width
+      height = item.height
     }
 
-    return { id, url, alt }
+    return { id, url, alt, width, height }
   }).filter(item => item.url) // Only return items with valid URLs
 })
 

--- a/utils/strapiImage.js
+++ b/utils/strapiImage.js
@@ -1,0 +1,41 @@
+/*
+  Normalises Strapi image fields into a flat { src, alt, width, height }.
+
+  Two shapes show up in this codebase:
+  1. micro-components.clients — { image, imageUrl, imageAlt, width, height }
+     Editor can override width/height; otherwise falls back to media's intrinsic size.
+  2. Raw media fields — flattened by strapi-plugin-transformer for most content types,
+     but blogs are on the transformer deny list, so they keep { data: { attributes: {...} } }.
+
+  `fallback` lets callers pass static defaults for fields the editor may have left blank.
+*/
+export function getStrapiImage(input, fallback = {}) {
+  const empty = {
+    src: fallback.src || '',
+    alt: fallback.alt || '',
+    width: fallback.width || null,
+    height: fallback.height || null,
+  }
+  if (!input) return empty
+
+  const root = input.data?.attributes || input.attributes || input
+
+  // micro-components.clients shape
+  if ('imageUrl' in root || 'imageAlt' in root) {
+    const media = root.image?.data?.attributes || root.image || {}
+    return {
+      src: media.url || root.imageUrl || empty.src,
+      alt: root.imageAlt || media.alternativeText || empty.alt,
+      width: root.width || media.width || empty.width,
+      height: root.height || media.height || empty.height,
+    }
+  }
+
+  // Raw media field
+  return {
+    src: root.url || empty.src,
+    alt: root.alternativeText || empty.alt,
+    width: root.width || empty.width,
+    height: root.height || empty.height,
+  }
+}


### PR DESCRIPTION
1. **Image helper update** — `utils/strapiImage.js` now handles both `micro-components.clients` (`{ image, imageUrl, imageAlt, width, height }`) and regular CMS media fields. It returns a simple `{ src, alt, width, height }` object. Custom width/height from CMS is used first, original media dimensions next, and fallback values last.

2. **CMS images cleaned up** — all components using CMS images now go through this helper. This removes a lot of repeated `getIconSrc`, `getImgUrl`, and manual image parsing code.

3. **Static images updated** — navbar, footer, trust badges, CTA masks, and decorative SVGs (play button, close icon, chevrons, social icons) now have fixed `width` / `height` values based on their original proportions.

4. **Blog images updated** — `useBlogData` and `pages/blog/[slug].vue` now also pass `coverImgWidth` / `coverImgHeight` with `coverImg`. Blog cards use a `1200×630` fallback if dimensions are missing.