### PR TITLE
FMST-2452: Guard CMS image rendering against missing/null sources

### DIFF
--- a/components/RelatedArticleCard.vue
+++ b/components/RelatedArticleCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <NuxtLink :to="articleLink">
+  <NuxtLink v-if="article" :to="articleLink">
     <img
       v-if="article.coverImg"
       :src="article.coverImg"
@@ -26,6 +26,7 @@ export default {
   },
   computed: {
     articleLink() {
+      if (!this.article) return '#'
       if (this.article.type) {
         return this.article.link
       }

--- a/components/RelatedArticleCard.vue
+++ b/components/RelatedArticleCard.vue
@@ -1,6 +1,7 @@
 <template>
   <NuxtLink :to="articleLink">
     <img
+      v-if="article.coverImg"
       :src="article.coverImg"
       class="rounded img-fluid"
       :alt="article.coverImgAlt"

--- a/components/blog/BlogCard.vue
+++ b/components/blog/BlogCard.vue
@@ -1,6 +1,7 @@
 <template>
   <NuxtLink :to="{ path: `/blog/${article.slug}/` }">
     <img
+      v-if="article.coverImg"
       :src="article.coverImg"
       class="rounded img-fluid"
       :alt="article.coverImgAlt"

--- a/components/blog/BlogCard.vue
+++ b/components/blog/BlogCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <NuxtLink :to="{ path: `/blog/${article.slug}/` }">
+  <NuxtLink v-if="article" :to="{ path: `/blog/${article.slug}/` }">
     <img
       v-if="article.coverImg"
       :src="article.coverImg"
@@ -16,7 +16,7 @@
         <h3 class="blog__title">{{ article.title }}</h3>
         <p class="mt-1 blog__desc">{{ article.description }}</p>
       </div>
-      <span class="mt-2 blog__timetoRead">
+      <span v-if="article.readingStats" class="mt-2 blog__timetoRead">
         <ClockIcon color="#828282" />
         {{ article.readingStats.text }}
       </span>

--- a/components/blog/BlogFeatured.vue
+++ b/components/blog/BlogFeatured.vue
@@ -4,6 +4,7 @@
     class="row px-3"
   >
     <img
+      v-if="article.coverImg"
       :src="article.coverImg"
       class="col-lg-6 rounded img-fluid featured__blog-img"
       :alt="article.coverImgAlt"

--- a/components/blog/BlogFeatured.vue
+++ b/components/blog/BlogFeatured.vue
@@ -1,5 +1,6 @@
 <template>
   <NuxtLink
+    v-if="article"
     :to="{ path: `/blog/${article.slug}/` }"
     class="row px-3"
   >
@@ -20,7 +21,7 @@
         <h3 class="blog__title">{{ article.title }}</h3>
         <p class="mt-1 blog__desc">{{ article.description }}</p>
       </div>
-      <span class="mt-2 blog__timetoRead">
+      <span v-if="article.readingStats" class="mt-2 blog__timetoRead">
         <ClockIcon color="#828282" />
         {{ article.readingStats.text }}
       </span>

--- a/components/comparision/FormBuilderComparisonTable.vue
+++ b/components/comparision/FormBuilderComparisonTable.vue
@@ -11,8 +11,9 @@
           <div class="formbuilder__logo-wrapper d-flex align-items-center justify-content-center text-center">
             <!-- If not using @nuxt/image, replace NuxtImg with img -->
             <NuxtImg
+              v-if="fb?.logo?.data?.attributes?.url"
               class="formbuilder__logo"
-              :src="fb?.logo?.data?.attributes?.url || ''"
+              :src="fb.logo.data.attributes.url"
               :alt="fb?.name || 'Form builder logo'"
               height="40"
               loading="lazy"
@@ -65,8 +66,9 @@
       >
         <div class="formbuilder__logo-wrapper d-flex align-items-center justify-content-center text-center">
           <NuxtImg
+            v-if="fb?.logo?.data?.attributes?.url"
             class="formbuilder__logo"
-            :src="fb?.logo?.data?.attributes?.url || ''"
+            :src="fb.logo.data.attributes.url"
             :alt="fb?.name || 'Form builder logo'"
             height="40"
             loading="lazy"

--- a/components/home/HeroTabShowcase/HeroTabs.vue
+++ b/components/home/HeroTabShowcase/HeroTabs.vue
@@ -25,7 +25,7 @@
             <h3 class="tab-title">{{ tab.title }}</h3>
             <ul class="tab-features">
               <li v-for="(feature, i) in tab.features" :key="i">
-                <span class="feature-icon">
+                <span class="feature-icon" v-if="feature.icon?.src">
                   <img
                     :src="feature.icon.src"
                     :alt="feature.text + ' icon'"
@@ -39,7 +39,7 @@
               </li>
             </ul>
           </div>
-          <div class="tab-right">
+          <div class="tab-right" v-if="tab.image?.src">
             <img
               :src="tab.image.src"
               :alt="tab.label + ' screenshot'"

--- a/components/strapi/HeroCenteredDark.vue
+++ b/components/strapi/HeroCenteredDark.vue
@@ -2,7 +2,7 @@
   <section
     class="hero"
     :style="{
-      backgroundImage: background.image?.url
+      backgroundImage: background?.image?.url
         ? `url(${background.image.url})`
         : '',
     }"

--- a/components/strapi/IntegrationCard.vue
+++ b/components/strapi/IntegrationCard.vue
@@ -1,16 +1,17 @@
 <template>
   <div class="integration-card">
     <div class="tools-container">
-      <img
-        v-for="tool in tools"
-        :key="tool.name"
-        :src="tool.icon"
-        :alt="tool.name"
-        class="tool-icon"
-        width="48"
-        height="48"
-        loading="lazy"
-      />
+      <template v-for="tool in tools" :key="tool.name">
+        <img
+          v-if="tool.icon"
+          :src="tool.icon"
+          :alt="tool.name"
+          class="tool-icon"
+          width="48"
+          height="48"
+          loading="lazy"
+        />
+      </template>
     </div>
     <div class="action">{{ action }}</div>
   </div>

--- a/components/strapi/Trustbadges.vue
+++ b/components/strapi/Trustbadges.vue
@@ -4,44 +4,26 @@
       <SectionTitle :heading="title" />
       <p>{{ description }}</p>
       <div class="trustbadge-wrapper">
-        <div class="rating-wrapper">
-          <nuxt-img src="/product-hunt.svg" alt="Product Hunt" class="logo" width="171" height="40" />
+        <div
+          v-for="(badge, i) in badges"
+          :key="badge.id || i"
+          class="rating-wrapper"
+        >
+          <nuxt-img
+            :src="logoFor(badge).src"
+            :alt="logoFor(badge).alt"
+            :width="logoFor(badge).width"
+            :height="logoFor(badge).height"
+            class="logo"
+          />
           <div class="rating">
-            <span class="rating-number">5/5</span>
-            <nuxt-img src="/5-stars.svg" alt="5 stars" class="rating-stars" width="139" height="24" />
-          </div>
-        </div>
-        <div class="rating-wrapper">
-          <nuxt-img src="/trustpilot.svg" alt="Trustpilot" class="logo" width="163" height="40" />
-          <div class="rating">
-            <span class="rating-number">4.4/5</span>
+            <span class="rating-number">{{ badge.ratingNumber }}</span>
             <nuxt-img
-              src="/4.5-stars.svg"
-              alt="4.5 stars"
+              :src="starsFor(badge).src"
+              :alt="starsFor(badge).alt"
+              :width="starsFor(badge).width"
+              :height="starsFor(badge).height"
               class="rating-stars"
-              width="139"
-              height="24"
-            />
-          </div>
-        </div>
-        <div class="rating-wrapper">
-          <nuxt-img src="/capterra.svg" alt="Capterra" class="logo" width="174" height="40" />
-          <div class="rating">
-            <span class="rating-number">5/5</span>
-            <nuxt-img src="/5-stars.svg" alt="5 stars" class="rating-stars" width="139" height="24" />
-          </div>
-        </div>
-
-        <div class="rating-wrapper">
-          <nuxt-img src="/g2-crowd.svg" alt="G2 Crowd" class="logo" width="40" height="40" />
-          <div class="rating">
-            <span class="rating-number">4.7/5</span>
-            <nuxt-img
-              src="/4.5-stars.svg"
-              alt="4.5 stars"
-              class="rating-stars"
-              width="139"
-              height="24"
             />
           </div>
         </div>
@@ -51,6 +33,8 @@
 </template>
 
 <script>
+import { getStrapiImage } from '@/utils/strapiImage'
+
 export default {
   props: {
     title: {
@@ -59,6 +43,18 @@ export default {
     },
     description: {
       type: String,
+    },
+    badges: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  methods: {
+    logoFor(badge) {
+      return getStrapiImage(badge?.logo)
+    },
+    starsFor(badge) {
+      return getStrapiImage(badge?.stars)
     },
   },
 }


### PR DESCRIPTION
fix: guard CMS image rendering against missing/null sources
Hides <img> tags where the CMS field is missing instead of
rendering a broken element or throwing on null deref.
Same root cause class as the FeatureShowcase crash.