### PR TITLE
Improve hero image responsiveness

### DIFF
--- a/components/HeroRowLayout.vue
+++ b/components/HeroRowLayout.vue
@@ -31,7 +31,7 @@
             :alt="heroImg.alt || 'Hero image'"
             :width="heroImg.width"
             :height="heroImg.height"
-            class="img-fluid hero__image"
+            class="hero__image"
           />
 
           <!-- Video thumbnail with play button when video is provided -->
@@ -150,7 +150,8 @@ export default {
 }
 
 .hero__image {
-  height: 100%;
+  max-height: 100%;
+  max-width: 100%;
 }
 
 .click-triggers {

--- a/components/features/FeatureDetailsSection.vue
+++ b/components/features/FeatureDetailsSection.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container py-5">
     <SectionTitle :heading="title" />
-    <p class="hero__subheading" v-if="description">
+    <p class="hero__subheading text-center" v-if="description">
       {{ description }}
     </p>
     <div class="row py-5">


### PR DESCRIPTION
Adjust the hero image class and constrain its dimensions to enhance responsiveness across different screen sizes.
<img width="3072" height="1728" alt="image" src="https://github.com/user-attachments/assets/55a25782-cdf2-4c82-b86a-7774310c5efe" />
<img width="3072" height="1728" alt="image" src="https://github.com/user-attachments/assets/b155f68d-f9be-426f-bbf3-40448d12c3da" />

Post Merge, add the image dimensions to affected images