### PR TITLE
Add optional chaining to template description handling

### DIFF
--- a/pages/templates/[slug].vue
+++ b/pages/templates/[slug].vue
@@ -10,7 +10,7 @@
 
             <!-- New paragraph for each line break -->
             <p
-              v-for="(line, index) in template.description.split('\n')"
+              v-for="(line, index) in template?.description?.split?.('\n')"
               :key="index"
               class="hero__subheading"
             >
@@ -44,7 +44,7 @@
 
               <!-- New paragraph for each line break -->
               <p
-                v-for="(line, index) in template.description.split('\n')"
+                v-for="(line, index) in template?.description?.split?.('\n')"
                 :key="index"
                 class="hero__subheading"
               >


### PR DESCRIPTION
Optional chaining has been implemented to enhance safety when splitting the template description by line breaks. This change prevents potential errors when the description is undefined or null.