### PR TITLE
Fix API Docs link in footer

### DIFF
--- a/components/v2/Footer.vue
+++ b/components/v2/Footer.vue
@@ -121,7 +121,7 @@
           <li>
             <NuxtLink to="/blog/" class="site-footer__link">Blog</NuxtLink>
           </li>
-          <li><a href="https://docs.formester.com/api/" class="site-footer__link">API Docs</a></li>
+          <li><a href="https://docs.formester.com/formester-api.html" class="site-footer__link">API Docs</a></li>
           <li><a href="https://help.formester.com/en/" class="site-footer__link">Help Center</a></li>
           <li>
             <NuxtLink to="/templates/" class="site-footer__link">1000+ Templates</NuxtLink>


### PR DESCRIPTION
Update the footer to point the API Docs link to the correct URL.