### PR TITLE
feat(blog): revamp listing & article pages

### DIFF
--- a/components/RelatedArticleCard.vue
+++ b/components/RelatedArticleCard.vue
@@ -1,58 +1,112 @@
 <template>
-  <NuxtLink v-if="article" :to="articleLink">
-    <img
-      v-if="article.coverImg"
-      :src="article.coverImg"
-      class="rounded img-fluid"
-      :alt="article.coverImgAlt"
-      :width="article.coverImgWidth || 1200"
-      :height="article.coverImgHeight || 630"
-      loading="lazy"
-    />
-    <div class="d-flex flex-column align-items-start mt-2">
-      <h3 class="article__title">{{ article.title }}</h3>
+  <NuxtLink v-if="article" :to="articleLink" class="rel-card">
+    <div v-if="article.coverImg" class="rel-card__media">
+      <img
+        :src="article.coverImg"
+        :alt="article.coverImgAlt"
+        :width="article.coverImgWidth || 1200"
+        :height="article.coverImgHeight || 630"
+        loading="lazy"
+      />
+    </div>
+    <div class="rel-card__body">
+      <h3 class="rel-card__title">{{ article.title }}</h3>
+      <p v-if="article.publishedAt" class="rel-card__meta">
+        <span>{{ formatDate(article.publishedAt) }}</span>
+        <template v-if="article.readingStats">
+          <span class="rel-card__sep">·</span>
+          <span>{{ article.readingStats.text }}</span>
+        </template>
+      </p>
     </div>
   </NuxtLink>
 </template>
 
-<script>
-import ClockIcon from './icons/ClockIcon.vue'
+<script setup>
+import { computed } from 'vue'
 
-export default {
-  name: 'RelatedArticleCard',
-  props: ['article'],
-  components: {
-    ClockIcon,
-  },
-  computed: {
-    articleLink() {
-      if (!this.article) return '#'
-      if (this.article.type) {
-        return this.article.link
-      }
-      return `/blog/${this.article.slug}/`
-    },
-  },
-  methods: {
-    formatDate(date) {
-      const options = { year: 'numeric', month: 'long', day: 'numeric' }
-      return new Date(date).toLocaleDateString('en', options)
-    },
-  },
+const props = defineProps({
+  article: { type: Object, default: null },
+})
+
+const articleLink = computed(() => {
+  if (!props.article) return '#'
+  if (props.article.type) {
+    return props.article.link
+  }
+  return `/blog/${props.article.slug}/`
+})
+
+const formatDate = (date) => {
+  const options = { year: 'numeric', month: 'long', day: 'numeric' }
+  return new Date(date).toLocaleDateString('en', options)
 }
 </script>
 
-<style>
-.article__title {
-  font-size: 1.2rem;
-  font-weight: 600;
-  line-height: 30px;
-  color: hsla(0, 0%, 20%, 1);
+<style scoped>
+.rel-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: #fff;
+  border: 1px solid var(--border-light);
+  border-radius: var(--r-2xl);
+  box-shadow: var(--shadow-xs);
+  overflow: hidden;
+  text-decoration: none;
+  transition: box-shadow 140ms ease, transform 140ms ease, border-color 140ms ease;
 }
 
-@media only screen and (max-width: 992px) {
-  .related-article-card {
-    padding: 1rem auto;
-  }
+.rel-card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lg);
+}
+
+.rel-card__media {
+  aspect-ratio: 1200 / 630;
+  overflow: hidden;
+  background: var(--gray-50);
+}
+
+.rel-card__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.rel-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-4) var(--space-5);
+}
+
+.rel-card__meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0;
+  margin-top: auto;
+  padding-top: var(--space-2);
+  font-size: 12.5px;
+  font-weight: var(--fw-medium);
+  color: var(--fg-muted);
+}
+
+.rel-card__sep {
+  color: var(--gray-300);
+}
+
+.rel-card__title {
+  font-size: var(--fs-md);
+  font-weight: var(--fw-bold);
+  line-height: 1.4;
+  color: var(--fg-1);
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 </style>

--- a/components/blog/BlogCard.vue
+++ b/components/blog/BlogCard.vue
@@ -1,73 +1,122 @@
 <template>
-  <NuxtLink v-if="article" :to="{ path: `/blog/${article.slug}/` }">
-    <img
-      v-if="article.coverImg"
-      :src="article.coverImg"
-      class="rounded img-fluid"
-      :alt="article.coverImgAlt"
-      :title="article.coverImgAlt"
-      :width="article.coverImgWidth || 1200"
-      :height="article.coverImgHeight || 630"
-      loading="lazy"
-    />
-    <div class="d-flex flex-column align-items-start">
-      <span class="blog__date mt-3">{{ formatDate(article.publishedAt) }}</span>
-      <div class="mt-2">
-        <h3 class="blog__title">{{ article.title }}</h3>
-        <p class="mt-1 blog__desc">{{ article.description }}</p>
-      </div>
-      <span v-if="article.readingStats" class="mt-2 blog__timetoRead">
-        <ClockIcon color="#828282" />
-        {{ article.readingStats.text }}
-      </span>
+  <NuxtLink v-if="article" :to="{ path: `/blog/${article.slug}/` }" class="bcard">
+    <div v-if="article.coverImg" class="bcard__media">
+      <img
+        :src="article.coverImg"
+        :alt="article.coverImgAlt"
+        :title="article.coverImgAlt"
+        :width="article.coverImgWidth || 1200"
+        :height="article.coverImgHeight || 630"
+        loading="lazy"
+      />
+    </div>
+    <div class="bcard__body">
+      <h3 class="bcard__title">{{ article.title }}</h3>
+      <p class="bcard__desc">{{ article.description }}</p>
+      <p class="bcard__meta">
+        <span>{{ formatDate(article.publishedAt) }}</span>
+        <template v-if="article.readingStats">
+          <span class="bcard__sep">·</span>
+          <span>{{ article.readingStats.text }}</span>
+        </template>
+      </p>
     </div>
   </NuxtLink>
 </template>
 
-<script>
-import ClockIcon from '../icons/ClockIcon.vue'
+<script setup>
+defineProps({
+  article: { type: Object, default: null },
+})
 
-export default {
-  name: 'BlogCard',
-  props: ['article'],
-  components: {
-    ClockIcon
-  },
-  methods: {
-    formatDate(date) {
-      const options = { year: 'numeric', month: 'long', day: 'numeric' }
-      return new Date(date).toLocaleDateString('en', options)
-    },
-  },
+const formatDate = (date) => {
+  const options = { year: 'numeric', month: 'long', day: 'numeric' }
+  return new Date(date).toLocaleDateString('en', options)
 }
 </script>
 
-<style>
-.blog__date {
-  background: hsla(0, 0%, 96%, 1);
-  color: hsla(0, 0%, 31%, 1);
-  padding: 0.5rem;
-  font-size: 12px;
-  line-height: 14px;
-  border-radius: 0.25rem;
-}
-.blog__title {
-  font-size: 1.5rem;
-  font-weight: bold;
-  line-height: 32px;
-  color: hsla(0, 0%, 20%, 1);
+<style scoped>
+.bcard {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: #fff;
+  border: 1px solid var(--border-light);
+  border-radius: var(--r-2xl);
+  box-shadow: var(--shadow-xs);
+  overflow: hidden;
+  text-decoration: none;
+  transition: box-shadow 140ms ease, transform 140ms ease, border-color 140ms ease;
 }
 
-.blog__desc {
-  font-size: 1rem;
-  line-height: 24px;
-  color: hsla(0, 0%, 31%, 1);
+.bcard:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lg);
+}
+
+.bcard:hover .bcard__title {
+  color: var(--violet-600);
+}
+
+.bcard__media {
+  aspect-ratio: 1200 / 630;
+  overflow: hidden;
+  background: var(--gray-50);
+}
+
+.bcard__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.bcard__body {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  gap: var(--space-2);
+  padding: var(--space-5);
+}
+
+.bcard__meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
   margin: 0;
+  margin-top: auto;
+  padding-top: var(--space-3);
+  font-size: 12.5px;
+  font-weight: var(--fw-medium);
+  color: var(--fg-muted);
 }
 
-.blog__timetoRead {
-  font-size: 12px;
-  line-height: 21px;
-  color: hsla(0, 0%, 51%, 1);
+.bcard__sep {
+  color: var(--gray-300);
 }
+
+.bcard__title {
+  font-size: var(--fs-lg);
+  font-weight: var(--fw-bold);
+  line-height: 1.35;
+  letter-spacing: -0.01em;
+  color: var(--fg-1);
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.bcard__desc {
+  font-size: var(--fs-sm);
+  line-height: 1.55;
+  color: var(--fg-2);
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 </style>

--- a/components/blog/BlogFeatured.vue
+++ b/components/blog/BlogFeatured.vue
@@ -1,54 +1,144 @@
 <template>
-  <NuxtLink
-    v-if="article"
-    :to="{ path: `/blog/${article.slug}/` }"
-    class="row px-3"
-  >
-    <img
-      v-if="article.coverImg"
-      :src="article.coverImg"
-      class="col-lg-6 rounded img-fluid featured__blog-img"
-      :alt="article.coverImgAlt"
-      :title="article.coverImgAlt"
-      :width="article.coverImgWidth || 1200"
-      :height="article.coverImgHeight || 630"
-    />
-    <div
-      class="col-lg-6 d-flex flex-column align-items-start mt-3 mt-lg-0 ps-0 ps-lg-4"
-    >
-      <span class="blog__date">{{ formatDate(article.publishedAt) }}</span>
-      <div class="mt-2">
-        <h3 class="blog__title">{{ article.title }}</h3>
-        <p class="mt-1 blog__desc">{{ article.description }}</p>
-      </div>
-      <span v-if="article.readingStats" class="mt-2 blog__timetoRead">
-        <ClockIcon color="#828282" />
-        {{ article.readingStats.text }}
-      </span>
+  <NuxtLink v-if="article" :to="{ path: `/blog/${article.slug}/` }" class="bfeat">
+    <div v-if="article.coverImg" class="bfeat__media">
+      <img
+        :src="article.coverImg"
+        :alt="article.coverImgAlt"
+        :title="article.coverImgAlt"
+        :width="article.coverImgWidth || 1200"
+        :height="article.coverImgHeight || 630"
+      />
+    </div>
+    <div class="bfeat__body">
+      <span class="bfeat__badge">Featured</span>
+      <p class="bfeat__meta">
+        <span>{{ formatDate(article.publishedAt) }}</span>
+        <template v-if="article.readingStats">
+          <span class="bfeat__sep">·</span>
+          <span>{{ article.readingStats.text }}</span>
+        </template>
+      </p>
+      <h3 class="bfeat__title">{{ article.title }}</h3>
+      <p class="bfeat__desc">{{ article.description }}</p>
+      <span class="bfeat__read">Read article <span aria-hidden="true">→</span></span>
     </div>
   </NuxtLink>
 </template>
 
-<script>
-import ClockIcon from '../icons/ClockIcon.vue'
+<script setup>
+defineProps({
+  article: { type: Object, default: null },
+})
 
-export default {
-  name: 'BlogFeatured',
-  props: ['article'],
-  components: {
-    ClockIcon,
-  },
-  methods: {
-    formatDate(date) {
-      const options = { year: 'numeric', month: 'long', day: 'numeric' }
-      return new Date(date).toLocaleDateString('en', options)
-    },
-  },
+const formatDate = (date) => {
+  const options = { year: 'numeric', month: 'long', day: 'numeric' }
+  return new Date(date).toLocaleDateString('en', options)
 }
 </script>
 
-<style>
-.featured__blog-img {
-  padding: 0;
+<style scoped>
+.bfeat {
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  background: #fff;
+  border: 1px solid var(--border-light);
+  border-radius: var(--r-2xl);
+  box-shadow: var(--shadow-xs);
+  overflow: hidden;
+  text-decoration: none;
+  transition: box-shadow 140ms ease, transform 140ms ease, border-color 140ms ease;
+}
+
+.bfeat:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lg);
+}
+
+.bfeat__media {
+  aspect-ratio: 1200 / 630;
+  overflow: hidden;
+  background: var(--gray-50);
+}
+
+.bfeat__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.bfeat__body {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: var(--space-8);
+}
+
+.bfeat__badge {
+  font-size: var(--fs-tiny);
+  font-weight: var(--fw-bold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--violet-600);
+  background: var(--violet-50);
+  border-radius: var(--r-full);
+  padding: 5px 12px;
+  line-height: 1;
+}
+
+.bfeat__meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0;
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-medium);
+  color: var(--fg-3);
+}
+
+.bfeat__sep {
+  color: var(--gray-300);
+}
+
+.bfeat__title {
+  font-size: clamp(22px, 2.4vw, 30px);
+  font-weight: var(--fw-bold);
+  line-height: 1.25;
+  letter-spacing: -0.02em;
+  color: var(--fg-1);
+  margin: 0;
+}
+
+.bfeat__desc {
+  font-size: var(--fs-md);
+  line-height: 1.6;
+  color: var(--fg-2);
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.bfeat__read {
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-semibold);
+  color: var(--violet-600);
+}
+
+.bfeat:hover .bfeat__read {
+  text-decoration: underline;
+}
+
+@media (max-width: 900px) {
+  .bfeat {
+    grid-template-columns: 1fr;
+  }
+
+  .bfeat__body {
+    padding: var(--space-5);
+  }
 }
 </style>

--- a/components/blog/BlogPostView.vue
+++ b/components/blog/BlogPostView.vue
@@ -1,57 +1,89 @@
 <template>
   <div>
-    <nav
-      v-if="tableOfContents.length"
-      class="navbar navbar-expand bg-white py-3"
-    >
-      <div class="collapse navbar-collapse">
-        <ul class="navbar-nav">
-          <li class="nav-item dropdown">
+    <!-- HERO -->
+    <section class="art-hero">
+      <div class="art-hero__inner">
+        <NuxtLink to="/blog/" class="art-back">
+          <svg width="15" height="15" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M10 4 6 8l4 4" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" /></svg>
+          All articles
+        </NuxtLink>
+        <h1 class="art-title">{{ blogData.title }}</h1>
+        <div class="art-byline">
+          <div v-if="blogData.author" class="art-author">
+            <span class="art-avatar" aria-hidden="true">{{ authorInitials }}</span>
             <a
-              class="dropdown-toggle"
-              href="#"
-              id="tocMenuLink"
-              role="button"
-              data-bs-toggle="dropdown"
-              aria-expanded="false"
-            >
-              Table of Contents
-            </a>
-            <ul class="dropdown-menu" aria-labelledby="tocMenuLink">
+              v-if="blogData.authorProfile"
+              :href="blogData.authorProfile"
+              target="_blank"
+              rel="noopener"
+              class="art-author__name"
+            >{{ blogData.author }}</a>
+            <span v-else class="art-author__name">{{ blogData.author }}</span>
+          </div>
+          <template v-if="blogData.publishedAt">
+            <span class="art-byline__dot"></span>
+            <span class="art-byline__meta">{{ formatDate(blogData.publishedAt) }}</span>
+          </template>
+          <template v-if="blogData.readingStats">
+            <span class="art-byline__dot"></span>
+            <span class="art-byline__meta">{{ blogData.readingStats.text }}</span>
+          </template>
+        </div>
+      </div>
+    </section>
+
+    <!-- BODY: TOC rail · article · share rail -->
+    <section class="art-section">
+      <div class="art-layout">
+        <aside v-if="tableOfContents.length" class="art-toc" aria-label="Table of contents">
+          <p class="art-toc__title">On this page</p>
+          <ul>
+            <li v-for="link of tableOfContents" :key="link.id">
+              <NuxtLink
+                :to="`#${link.id}`"
+                :class="[`toc-l${link.level}`, { active: activeId === link.id }]"
+                :title="link.text"
+              >
+                {{ link.text }}
+              </NuxtLink>
+            </li>
+          </ul>
+        </aside>
+        <div v-else></div>
+
+        <article class="art-body">
+          <!-- Mobile/tablet TOC accordion -->
+          <details v-if="tableOfContents.length" class="toc-accordion">
+            <summary>On this page</summary>
+            <ul>
               <li v-for="link of tableOfContents" :key="link.id">
-                <NuxtLink class="dropdown-link" :to="`#${link.id}`">
-                  {{ link.text }}
-                </NuxtLink>
+                <NuxtLink :to="`#${link.id}`" :class="`toc-l${link.level}`">{{ link.text }}</NuxtLink>
               </li>
             </ul>
-          </li>
-        </ul>
+          </details>
+
+          <div class="blog__content" ref="blogContent">
+            <div class="nuxt-content" v-html="processedBody" />
+
+            <div class="popup__img" :style="{ display: showPopup ? 'block' : 'none' }">
+              <span class="image-preview-close" @click="closePopup">&times;</span>
+              <img :src="popupImageSrc" :alt="popupImageAlt" @click="closePopup" />
+            </div>
+          </div>
+
+          <!-- Inline share: shown only when the side rail is hidden (≤1080px) -->
+          <div v-if="$slots.actions" class="art-share-inline" aria-label="Share this article">
+            <span class="art-share-inline__label">Share this article</span>
+            <slot name="actions" />
+          </div>
+        </article>
+
+        <aside v-if="$slots.actions" class="art-share" aria-label="Share this article">
+          <span class="art-share__label">Share</span>
+          <slot name="actions" />
+        </aside>
       </div>
-    </nav>
-
-    <h1 class="article__heading">{{ blogData.title }}</h1>
-
-    <div v-if="blogData.author" class="sm-text mt-1 article__author-section">
-      by
-      <a
-        v-if="blogData.authorProfile"
-        :href="blogData.authorProfile"
-        target="_blank"
-        rel="noopener"
-      >
-        <span class="article__author">{{ blogData.author }}</span>
-      </a>
-      <span v-else class="article__author">{{ blogData.author }}</span>
-    </div>
-
-    <div class="blog__content" ref="blogContent">
-      <div class="nuxt-content" v-html="processedBody" />
-
-      <div class="popup__img" :style="{ display: showPopup ? 'block' : 'none' }">
-        <span class="image-preview-close" @click="closePopup">&times;</span>
-        <img :src="popupImageSrc" :alt="popupImageAlt" @click="closePopup" />
-      </div>
-    </div>
+    </section>
   </div>
 </template>
 
@@ -65,10 +97,26 @@ const props = defineProps({
   },
 })
 
+const authorInitials = computed(() =>
+  (props.blogData?.author || '')
+    .split(/\s+/)
+    .map((w) => w[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join('')
+    .toUpperCase()
+)
+
+const formatDate = (date) => {
+  const options = { year: 'numeric', month: 'long', day: 'numeric' }
+  return new Date(date).toLocaleDateString('en', options)
+}
+
 const showPopup = ref(false)
 const popupImageSrc = ref('')
 const popupImageAlt = ref('')
 const blogContent = ref(null)
+const activeId = ref('')
 
 const slugifyHeading = (text) =>
   text
@@ -141,93 +189,346 @@ const setupImageClickHandlers = () => {
   })
 }
 
+// Scrollspy: highlight the TOC item for the heading currently in view
+let headingObserver = null
+const setupScrollspy = () => {
+  nextTick(() => {
+    if (!blogContent.value || !tableOfContents.value.length) return
+    headingObserver?.disconnect()
+    headingObserver = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            activeId.value = entry.target.id
+          }
+        }
+      },
+      { rootMargin: '-90px 0px -70% 0px', threshold: 0 }
+    )
+    blogContent.value
+      .querySelectorAll('.nuxt-content h2[id], .nuxt-content h3[id]')
+      .forEach((h) => headingObserver.observe(h))
+  })
+}
+
 const keyHandler = (evt) => {
   if (evt.key === 'Escape') closePopup()
 }
 
 onMounted(() => {
   setupImageClickHandlers()
+  setupScrollspy()
   document.addEventListener('keydown', keyHandler)
 })
 
 onBeforeUnmount(() => {
   document.removeEventListener('keydown', keyHandler)
+  headingObserver?.disconnect()
 })
 
-watch(() => props.blogData?.body, setupImageClickHandlers)
+watch(() => props.blogData?.body, () => {
+  setupImageClickHandlers()
+  setupScrollspy()
+})
 </script>
 
 <style scoped>
-nav {
-  position: sticky;
-  top: 72px;
-  z-index: 100;
+/* ─── Hero ─────────────────────────────────────────────── */
+.art-hero {
+  background: linear-gradient(180deg, var(--violet-25), #fff 78%);
+  border-bottom: 1px solid var(--border-light);
+  padding: 122px var(--space-6) 40px;
 }
 
-.article__heading {
-  font-size: 2.25rem;
-  font-weight: 700;
-  line-height: 44px;
-  color: var(--clr-text-primary);
-  margin-bottom: 0.25rem;
+.art-hero__inner {
+  max-width: 760px;
+  margin: 0 auto;
 }
 
-.sm-text {
+.art-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 13.5px;
+  font-weight: var(--fw-semibold);
+  color: var(--fg-3);
+  text-decoration: none;
+  margin-bottom: 26px;
+  transition: color 150ms ease;
+}
+
+.art-back svg {
+  transition: transform 150ms ease;
+}
+
+.art-back:hover {
+  color: var(--violet-600);
+}
+
+.art-back:hover svg {
+  transform: translateX(-3px);
+}
+
+.art-title {
+  font-size: clamp(30px, 4vw, 46px);
+  font-weight: var(--fw-bold);
+  line-height: 1.08;
+  letter-spacing: -0.025em;
+  color: var(--fg-1);
+  margin: 0 0 22px;
+  text-wrap: balance;
+}
+
+.art-byline {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.art-author {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+}
+
+.art-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background: var(--violet-50);
+  color: var(--violet-600);
   font-size: 14px;
-  line-height: 21px;
-  color: hsla(0, 0%, 31%, 1);
+  font-weight: var(--fw-bold);
+  letter-spacing: 0.02em;
+  flex-shrink: 0;
 }
 
-.article__author-section {
-  opacity: 0.75;
+.art-author__name {
+  font-size: 14.5px;
+  font-weight: var(--fw-semibold);
+  color: var(--fg-1);
+  line-height: 1.3;
+  text-decoration: none;
 }
 
-.article__author {
-  font-weight: 600;
+a.art-author__name:hover {
+  color: var(--violet-600);
 }
 
-.blog__content img {
+.art-byline__dot {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--fg-muted);
+}
+
+.art-byline__meta {
+  font-size: 13.5px;
+  color: var(--fg-3);
+}
+
+/* ─── Layout: TOC rail · body · share rail ─────────────── */
+.art-section {
+  background: #fff;
+  padding: 48px var(--space-6) 24px;
+}
+
+.art-layout {
+  display: grid;
+  grid-template-columns: 232px minmax(0, 720px) 64px;
+  gap: 48px;
+  max-width: 1140px;
+  margin: 0 auto;
+  justify-content: center;
+}
+
+.art-toc {
+  position: sticky;
+  top: 104px;
+  align-self: start;
+  max-height: calc(100vh - 130px);
+  overflow-y: auto;
+}
+
+.art-toc__title {
+  font-size: 11px;
+  font-weight: var(--fw-bold);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  margin: 0 0 14px;
+}
+
+.art-toc ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  border-left: 2px solid var(--border-light);
+}
+
+.art-toc a {
+  display: block;
+  font-size: 13.5px;
+  line-height: 1.4;
+  color: var(--fg-3);
+  text-decoration: none;
+  padding: 7px 0 7px 16px;
+  margin-left: -2px;
+  border-left: 2px solid transparent;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: color 140ms ease, border-color 140ms ease;
+}
+
+.art-toc a.toc-l3 {
+  padding-left: 30px;
+  font-size: 12.5px;
+}
+
+.art-toc a:hover {
+  color: var(--violet-600);
+}
+
+.art-toc a.active {
+  color: var(--violet-600);
+  font-weight: var(--fw-semibold);
+  border-left-color: var(--violet-500);
+}
+
+.art-share {
+  position: sticky;
+  top: 104px;
+  align-self: start;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.art-share__label {
+  font-size: 10px;
+  font-weight: var(--fw-bold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  margin-bottom: 2px;
+}
+
+.art-body {
+  min-width: 0;
+}
+
+/* ─── Mobile TOC accordion ─────────────────────────────── */
+.toc-accordion {
+  display: none;
+  border: 1px solid var(--border-light);
+  border-radius: var(--r-xl);
+  background: var(--gray-25);
+  padding: var(--space-3) var(--space-4);
+  margin-bottom: var(--space-5);
+}
+
+.toc-accordion summary {
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-semibold);
+  color: var(--fg-1);
+  cursor: pointer;
+}
+
+.toc-accordion ul {
+  list-style: none;
+  margin: var(--space-3) 0 0;
+  padding: 0;
+}
+
+.toc-accordion a {
+  display: block;
+  padding: 6px 0;
+  font-size: var(--fs-sm);
+  color: var(--fg-2);
+  text-decoration: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.toc-accordion a.toc-l3 {
+  padding-left: var(--space-4);
+  color: var(--fg-3);
+}
+
+.toc-accordion a:hover {
+  color: var(--violet-600);
+}
+
+.art-share-inline {
+  display: none;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: var(--space-8);
+  padding-top: var(--space-5);
+  border-top: 1px solid var(--border-light);
+}
+
+.art-share-inline__label {
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-semibold);
+  color: var(--fg-2);
+  margin-right: 4px;
+}
+
+.art-share-inline :deep(.social__links) {
+  flex-direction: row;
+}
+
+@media (max-width: 1080px) {
+  .art-layout {
+    grid-template-columns: 200px minmax(0, 1fr);
+    gap: 40px;
+  }
+
+  .art-share {
+    display: none;
+  }
+
+  .art-share-inline {
+    display: flex;
+  }
+}
+
+@media (max-width: 900px) {
+  .art-layout {
+    grid-template-columns: 1fr;
+    gap: 0;
+    max-width: 720px;
+  }
+
+  .art-toc {
+    display: none;
+  }
+
+  .toc-accordion {
+    display: block;
+  }
+
+  .art-hero {
+    padding: 100px var(--space-4) 32px;
+  }
+}
+
+.blog__content :deep(img) {
   cursor: zoom-in;
 }
 
-#tocMenuLink {
-  color: #777;
-  font-size: 16px;
-}
-
-.dropdown-menu {
-  border: 1px solid #e5e7eb;
-  border-radius: 8px;
-  box-shadow: 0 10px 25px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-  backdrop-filter: blur(12px);
-  background-color: rgba(255, 255, 255, 0.95);
-  max-height: 450px;
-  overflow-y: auto;
-  overflow-x: hidden;
-  padding: 8px 0;
-  margin-top: 8px;
-}
-
-.dropdown-link {
-  padding: 12px 16px;
-  min-width: 750px;
-  width: 100%;
-  display: block;
-  color: #374151;
-  text-decoration: none;
-  font-size: 14px;
-  line-height: 1.4;
-  transition: all 0.2s ease;
-  border-left: 3px solid transparent;
-}
-
-.dropdown-link:hover {
-  background-color: #f3f4f6;
-  color: var(--clr-primary);
-  border-left-color: var(--clr-primary);
-  text-decoration: none;
-}
-
+/* ─── Image popup ──────────────────────────────────────── */
 .popup__img {
   position: fixed;
   top: 0;
@@ -260,104 +561,155 @@ nav {
   object-fit: cover;
 }
 
-@media only screen and (max-width: 992px) {
-  nav {
-    top: 60px;
-  }
-  .dropdown-link {
-    min-width: 680px;
-  }
-}
-
 @media only screen and (max-width: 768px) {
-  .dropdown-link {
-    min-width: 480px;
-  }
   .popup__img img {
     width: 90%;
-  }
-}
-
-@media only screen and (max-width: 576px) {
-  .dropdown-link {
-    min-width: 370px;
-  }
-}
-
-@media only screen and (max-width: 432px) {
-  .dropdown-link {
-    min-width: 320px;
-  }
-}
-
-@media only screen and (max-width: 360px) {
-  .dropdown-link {
-    min-width: 250px;
   }
 }
 </style>
 
 <style>
+/* Article body typography (CKEditor/markdown output) */
 .nuxt-content {
-  margin-top: 18px;
-  font-size: 16px;
-  line-height: 24px;
-  letter-spacing: 0.4px;
-  color: var(--clr-text-primary);
+  font-size: 17px;
+  line-height: 1.75;
+  color: var(--fg-2);
+}
+
+.nuxt-content > p:first-of-type {
+  font-size: 19px;
+  line-height: 1.65;
+  color: var(--fg-1);
 }
 
 .nuxt-content p {
-  margin-bottom: 1.4rem;
+  margin-bottom: 18px;
 }
 
 .nuxt-content h2 {
-  font-size: 30px;
-  font-weight: 700;
-  line-height: 38px;
-  color: var(--clr-text-primary);
-  margin-top: 64px;
-  margin-bottom: 24px;
+  font-size: 26px;
+  font-weight: var(--fw-bold);
+  line-height: 1.3;
+  letter-spacing: -0.02em;
+  color: var(--fg-1);
+  margin-top: 44px;
+  margin-bottom: 16px;
+  scroll-margin-top: 96px;
 }
 
 .nuxt-content h3 {
-  font-size: 24px;
-  font-weight: 600;
-  line-height: 28px;
-  color: var(--clr-text-primary);
-  margin-top: 48px;
-  margin-bottom: 24px;
+  font-size: 19px;
+  font-weight: var(--fw-semibold);
+  line-height: 1.35;
+  letter-spacing: -0.01em;
+  color: var(--fg-1);
+  margin-top: 30px;
+  margin-bottom: 12px;
+  scroll-margin-top: 96px;
+}
+
+.nuxt-content strong {
+  color: var(--fg-1);
+  font-weight: var(--fw-semibold);
 }
 
 .nuxt-content a {
-  color: var(--clr-primary);
-  text-decoration: underline;
+  color: var(--violet-500);
+  font-weight: var(--fw-medium);
+  text-decoration: none;
+  border-bottom: 1px solid var(--violet-100);
+  transition: border-color 150ms ease, color 150ms ease;
+}
+
+.nuxt-content a:hover {
+  color: var(--violet-700);
+  border-color: var(--violet-300);
 }
 
 .nuxt-content img {
   height: auto;
   width: 100%;
-  margin-top: 8px;
-  margin-bottom: 16px;
+  margin: var(--space-2) 0 var(--space-4);
+  border-radius: var(--r-xl);
+  border: 1px solid var(--border-light);
+  box-shadow: var(--shadow-xs);
 }
 
 .nuxt-content ul li,
 .nuxt-content ol li {
-  margin-top: 0px;
-  margin-bottom: 16px;
+  margin-bottom: 12px;
+}
+
+.nuxt-content blockquote {
+  border-left: 3px solid var(--violet-300);
+  padding: 6px 0 6px 22px;
+  margin: 26px 0;
+  font-size: 18px;
+  line-height: 1.6;
+  color: var(--fg-1);
+  font-style: italic;
+}
+
+.nuxt-content blockquote p:last-child {
+  margin-bottom: 0;
+}
+
+.nuxt-content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: var(--space-6) 0;
+  font-size: var(--fs-sm);
+}
+
+.nuxt-content table th {
+  background: var(--gray-50);
+  color: var(--fg-1);
+  font-weight: var(--fw-semibold);
+  text-align: left;
+}
+
+.nuxt-content table th,
+.nuxt-content table td {
+  border: 1px solid var(--border-light);
+  padding: 10px 14px;
+}
+
+.nuxt-content code {
+  background: var(--gray-100);
+  border-radius: var(--r);
+  padding: 2px 6px;
+  font-size: 14px;
+  color: var(--violet-600);
+}
+
+.nuxt-content pre {
+  background: var(--gray-900);
+  color: #e4e7ec;
+  border-radius: var(--r-xl);
+  padding: var(--space-4) var(--space-5);
+  overflow-x: auto;
+  margin: var(--space-6) 0;
+}
+
+.nuxt-content pre code {
+  background: none;
+  color: inherit;
+  padding: 0;
+}
+
+.nuxt-content hr {
+  border: 0;
+  border-top: 1px solid var(--border-light);
+  margin: var(--space-8) 0;
 }
 
 @media only screen and (max-width: 768px) {
   .nuxt-content h2 {
-    margin-top: 16px;
+    margin-top: 32px;
   }
 
   .nuxt-content h3 {
-    margin-top: 16px;
-  }
-
-  .nuxt-content img {
-    margin-top: 8px;
-    margin-bottom: 12px;
+    margin-top: 24px;
   }
 }
 </style>

--- a/components/icons/IconFacebookSocial.vue
+++ b/components/icons/IconFacebookSocial.vue
@@ -1,0 +1,8 @@
+<template>
+  <svg :width="size" :height="size" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z" />
+  </svg>
+</template>
+<script setup>
+defineProps({ size: { type: [Number, String], default: 16 } })
+</script>

--- a/components/icons/IconLinkChain.vue
+++ b/components/icons/IconLinkChain.vue
@@ -1,0 +1,9 @@
+<template>
+  <svg :width="size" :height="size" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M10 13a5 5 0 0 0 7 0l3-3a5 5 0 0 0-7-7l-1 1" />
+    <path d="M14 11a5 5 0 0 0-7 0l-3 3a5 5 0 0 0 7 7l1-1" />
+  </svg>
+</template>
+<script setup>
+defineProps({ size: { type: [Number, String], default: 16 } })
+</script>

--- a/components/icons/IconLinkedinSocial.vue
+++ b/components/icons/IconLinkedinSocial.vue
@@ -1,0 +1,8 @@
+<template>
+  <svg :width="size" :height="size" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M19 3a2 2 0 012 2v14a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h14m-.5 15.5v-5.3a3.26 3.26 0 00-3.26-3.26c-.85 0-1.84.52-2.32 1.3v-1.11h-2.79v8.37h2.79v-4.93c0-.77.62-1.4 1.39-1.4a1.4 1.4 0 011.4 1.4v4.93h2.79M6.88 8.56a1.68 1.68 0 001.68-1.68c0-.93-.75-1.69-1.68-1.69a1.69 1.69 0 00-1.69 1.69c0 .93.76 1.68 1.69 1.68m1.39 9.94v-8.37H5.5v8.37h2.77z" />
+  </svg>
+</template>
+<script setup>
+defineProps({ size: { type: [Number, String], default: 16 } })
+</script>

--- a/components/icons/IconXSocial.vue
+++ b/components/icons/IconXSocial.vue
@@ -1,0 +1,8 @@
+<template>
+  <svg :width="size" :height="size" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L2.25 2.25h6.834l4.258 5.622 4.902-5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+  </svg>
+</template>
+<script setup>
+defineProps({ size: { type: [Number, String], default: 16 } })
+</script>

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -1,19 +1,12 @@
 <template>
   <div>
-    <div class="container position-relative mt-5">
-      <article
-        v-if="blogData"
-        class="article-container container mw-920"
-        :class="{ 'mb-3rem': !(blogData?.cta && blogData.cta.hidden) }"
-      >
-        <div class="blog__header">
-          <NuxtLink
-            to="/blog/"
-            class="blog__back"
-            @click.prevent="goBack"
-          >
-            <span>← Back</span>
-          </NuxtLink>
+    <div class="read-progress" aria-hidden="true">
+      <div class="read-progress__fill" :style="{ transform: `scaleX(${readProgress})` }"></div>
+    </div>
+
+    <div v-if="blogData" :class="{ 'mb-3rem': !(blogData?.cta && blogData.cta.hidden) }">
+        <BlogPostView v-if="blogPostViewData" :blog-data="blogPostViewData">
+          <template #actions>
           <div class="social__links">
             <a
               :href="`https://twitter.com/intent/tweet?url=${encodedUrl}&text=${blogData?.title} by @_Formester_ `"
@@ -21,7 +14,7 @@
               class="social-icons"
               target="_blank"
             >
-              <TwitterIcon />
+              <IconXSocial />
             </a>
             <a
               :href="`https://www.facebook.com/sharer.php?u=${encodedUrl}`"
@@ -29,7 +22,7 @@
               class="social-icons"
               target="_blank"
             >
-              <FacebookIcon />
+              <IconFacebookSocial />
             </a>
             <a
               :href="`https://www.linkedin.com/shareArticle?mini=true&url=${encodedUrl}`"
@@ -37,68 +30,46 @@
               class="social-icons"
               target="_blank"
             >
-              <LinkdinIcon />
+              <IconLinkedinSocial />
             </a>
             <span class="social-icons" @click="copyToClipboard">
-              <CopyLinkIcon />
+              <IconLinkChain />
             </span>
           </div>
-        </div>
-        <div class="d-flex sm-text my-2 datentimeToRead">
-          <span>{{ formatDate(blogData?.publishedAt) }}</span>
-          <span>|</span>
-          <div
-            class="d-flex align-items-center justify-content-center timeToRead"
-          >
-            <ClockIcon color="#4f4f4f" />
-            <span>{{ blogData?.readingStats?.text }}</span>
-          </div>
-        </div>
-        <BlogPostView v-if="blogPostViewData" :blog-data="blogPostViewData" />
+          </template>
+        </BlogPostView>
         <notifications position="bottom right" class="my-notification" />
 
-        <div v-if="relatedArticles" class="mt-5">
-          <h2 class="article__sub-heading">Related Blogs</h2>
-          <div class="row mt-4">
-            <RelatedArticleCard
-              v-for="relatedArticle in relatedArticles"
-              :key="relatedArticle.slug"
-              :article="relatedArticle"
-              class="col-lg-6 related-article-card"
-            />
+        <div v-if="relatedArticles && relatedArticles.length" class="container related-container">
+          <div class="related-section">
+            <div class="section-label">
+              <h2>Related Blogs</h2>
+              <span class="rule"></span>
+            </div>
+            <div class="related-grid">
+              <RelatedArticleCard
+                v-for="relatedArticle in relatedArticles"
+                :key="relatedArticle.slug"
+                :article="relatedArticle"
+              />
+            </div>
           </div>
         </div>
-
-        <!--
-          <template>
-            <div class="mt-5" id="disqus_thread"></div>
-          </template>
-
-          <noscript
-            >Please enable JavaScript to view the
-            <a href="https://disqus.com/?ref_noscript"
-              >comments powered by Disqus.</a
-            ></noscript
-          >
-        -->
-      </article>
     </div>
     <CallToActionSection :content="blogData?.cta" />
   </div>
 </template>
 
 <script setup>
-import ClockIcon from '../../components/icons/ClockIcon.vue'
-import TwitterIcon from '../../components/icons/twitter.vue'
-import FacebookIcon from '../../components/icons/facebook.vue'
-import LinkdinIcon from '../../components/icons/linkdin.vue'
-import CopyLinkIcon from '../../components/icons/copyLink.vue'
+import IconXSocial from '../../components/icons/IconXSocial.vue'
+import IconFacebookSocial from '../../components/icons/IconFacebookSocial.vue'
+import IconLinkedinSocial from '../../components/icons/IconLinkedinSocial.vue'
+import IconLinkChain from '../../components/icons/IconLinkChain.vue'
 import getSiteMeta from '../../utils/getSiteMeta'
 import readingTime from '@/utils/readingTime'
 import { getBlogBySlug, getAllBlogs } from '@/utils/getAllBlogs'
 
 const route = useRoute()
-const router = useRouter()
 const config = useRuntimeConfig()
 const { $notify } = useNuxtApp()
 
@@ -155,20 +126,31 @@ const blogPostViewData = computed(() => {
     authorProfile: blogData.value.authorProfile,
     coverImgUrl: null,
     coverImgAlt: blogData.value.coverImgAlt,
+    publishedAt: blogData.value.publishedAt,
+    readingStats: blogData.value.readingStats,
   }
+})
+
+// Reading progress bar
+const readProgress = ref(0)
+const onScroll = () => {
+  const doc = document.documentElement
+  const total = doc.scrollHeight - window.innerHeight
+  readProgress.value = total > 0 ? Math.min(1, window.scrollY / total) : 0
+}
+
+onMounted(() => {
+  window.addEventListener('scroll', onScroll, { passive: true })
+  onScroll()
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('scroll', onScroll)
 })
 
 const formatDate = (date) => {
   const options = { year: 'numeric', month: 'long', day: 'numeric' }
   return new Date(date).toLocaleDateString('en', options)
-}
-
-const goBack = () => {
-  if (process.client && window.history.length > 1) {
-    router.back()
-  } else {
-    router.push('/blog/')
-  }
 }
 
 const copyToClipboard = () => {
@@ -307,72 +289,102 @@ useJsonld(jsonldData.value)
 </script>
 
 <style scoped>
-p {
-  margin-bottom: 2rem;
+.read-progress {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  z-index: 2000;
+  background: transparent;
+  pointer-events: none;
 }
 
-.article-container {
-  margin-top: 9rem;
-}
-
-.article__sub-heading {
-  font-size: 1.5rem;
-  font-weight: 600;
-  line-height: 36px;
-  color: var(--clr-text-primary);
-}
-
-.article__desc {
-  font-size: 17px;
-  line-height: 31px;
-  color: var(--clr-text-primary);
-}
-
-.sm-text {
-  font-size: 14px;
-  line-height: 21px;
-  color: hsla(0, 0%, 31%, 1);
-}
-
-.mw-920 {
-  max-width: 920px;
-}
-
-.mt-8rem {
-  margin-block: 8rem;
+.read-progress__fill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--violet-300), var(--violet-500));
+  transform-origin: left;
+  transform: scaleX(0);
 }
 
 .mb-3rem {
   margin-bottom: 3rem;
 }
 
-.datentimeToRead {
-  gap: 0.75rem;
-  opacity: 0.5;
-}
-
-.timeToRead {
-  gap: 0.5rem;
-}
-
-.blog__header {
-  margin-top: -4rem;
-  justify-content: space-between;
-  display: flex;
-}
-
-.blog__header span {
-  color: #777;
-}
-
+/* share buttons rendered into the article's right rail */
 .social__links {
   display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
 .social-icons {
-  margin: 0 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 11px;
+  border: 1px solid var(--border-light);
+  background: #fff;
   cursor: pointer;
-  fill: #000;
+  color: var(--fg-3);
+  transition: all 150ms ease;
+}
+
+.social-icons:hover {
+  background: var(--bg-violet-25);
+  border-color: var(--violet-300);
+  color: var(--violet-600);
+  transform: translateY(-2px);
+}
+
+.related-container {
+  max-width: 1140px;
+}
+
+.section-label {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 26px;
+}
+
+.section-label h2 {
+  font-size: 21px;
+  font-weight: var(--fw-bold);
+  letter-spacing: -0.01em;
+  color: var(--fg-1);
+  margin: 0;
+}
+
+.section-label .rule {
+  flex: 1;
+  height: 1px;
+  background: var(--border-light);
+}
+
+.related-section {
+  margin-top: var(--space-10);
+  padding-top: var(--space-10);
+  border-top: 1px solid var(--border-light);
+}
+
+.related-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-4);
+}
+
+@media (max-width: 1100px) {
+  .related-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 600px) {
+  .related-grid {
+    grid-template-columns: 1fr;
+  }
 }
 </style>
-

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -14,11 +14,10 @@
       <h2 class="section__heading" id="all-blogs">All Blogs</h2>
       <div class="blog-container-wrapper">
         <div class="blog-container">
-          <transition-group name="fade" tag="div" class="row" mode="out-in">
+          <transition-group name="fade" tag="div" class="blog-grid" mode="out-in">
             <BlogCard
               v-for="article in paginatedArticles"
               :key="article.slug"
-              class="col-lg-4 mt-3 mb-5"
               :article="article"
             />
           </transition-group>
@@ -33,7 +32,7 @@
     <nav v-if="totalPages > 1">
       <div class="custom-pagination-bar">
         <span class="custom-page-btn prev disabled">
-          Previous
+          ← Previous
         </span>
         <div class="custom-pagination-center">
           <span v-for="item in paginationPages" :key="item.key">
@@ -54,13 +53,13 @@
           class="custom-page-btn next"
           :to="`/blog/page/2/`"
         >
-          Next
+          Next →
         </nuxt-link>
         <span
           v-else
           class="custom-page-btn next disabled"
         >
-          Next
+          Next →
         </span>
       </div>
     </nav>
@@ -200,23 +199,42 @@ useJsonld([
   }
 }
 .section__heading {
-  font-size: 32px;
-  margin-top: 32px;
+  font-size: clamp(22px, 2.4vw, 28px);
+  margin-top: 48px;
+  margin-bottom: 24px;
+}
+
+.blog-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-6);
+  margin-bottom: var(--space-8);
+}
+
+@media (max-width: 991px) {
+  .blog-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 600px) {
+  .blog-grid {
+    grid-template-columns: 1fr;
+  }
 }
 @media (max-width: 600px) {
   .section__heading {
-    font-size: 24px;
     margin-top: 24px;
   }
 }
 .custom-pagination-bar {
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
   width: 100%;
-  margin: 64px auto;
+  margin: 48px auto 64px;
   padding: 32px 0px;
-  border-top: 1px solid #eaecf0;
+  border-top: 1px solid var(--border-light);
   flex-wrap: wrap;
   gap: 12px;
 }
@@ -224,8 +242,7 @@ useJsonld([
   display: flex;
   justify-content: center;
   align-items: center;
-  flex: 1;
-  gap: 8px;
+  gap: 6px;
   flex-wrap: wrap;
 }
 
@@ -252,35 +269,46 @@ useJsonld([
   justify-content: center;
   text-decoration: none;
   background: #fff;
-  border-radius: 4px;
-  min-width: 44px;
+  border: 1px solid transparent;
+  border-radius: var(--r-full);
+  min-width: 40px;
   min-height: 40px;
-  font-weight: 600;
-  font-size: var(--ft-small-body);
-  color: var(--clr-text-secondary);
+  font-weight: var(--fw-semibold);
+  font-size: var(--fs-sm);
+  color: var(--fg-2);
   cursor: pointer;
   outline: none;
-  transition: background 0.2s, color 0.2s, border 0.2s;
-  padding: 0 16px;
+  transition: background 140ms ease, color 140ms ease, border-color 140ms ease;
+  padding: 0 14px;
 }
 
 .custom-page-btn:hover {
-  background: #f9fafb;
+  background: var(--bg-violet-25);
+  color: var(--violet-600);
 }
-.custom-page-btn.active,
+.custom-page-btn.active {
+  background: var(--violet-500);
+  border-color: var(--violet-500);
+  color: #fff;
+  cursor: default;
+}
 .custom-page-btn.disabled {
-  background: #f9fafb;
-  color: var(--clr-text-secondary);
-  border: 1px solid #d0d5dd;
+  background: var(--gray-50);
+  color: var(--fg-muted);
+  border: 1px solid var(--border-light);
   cursor: default;
 }
 .custom-page-btn.prev,
 .custom-page-btn.next {
-  border: 1px solid #d0d5dd;
-  min-width: 120px;
+  border: 1px solid var(--border-dark);
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 0 18px;
+}
+.custom-page-btn.next:not(.disabled):hover,
+.custom-page-btn.prev:not(.disabled):hover {
+  border-color: var(--violet-300);
 }
 .custom-page-btn.disabled {
   opacity: 1;

--- a/pages/blog/page/[number].vue
+++ b/pages/blog/page/[number].vue
@@ -4,11 +4,10 @@
       <h2 class="section__heading" id="all-blogs">All Blogs</h2>
       <div class="blog-container-wrapper">
         <div class="blog-container">
-          <transition-group name="fade" tag="div" class="row" mode="out-in">
+          <transition-group name="fade" tag="div" class="blog-grid" mode="out-in">
             <BlogCard
               v-for="article in paginatedArticles"
               :key="article.slug"
-              class="col-lg-4 mt-3 mb-5"
               :article="article"
             />
           </transition-group>
@@ -27,13 +26,13 @@
           class="custom-page-btn prev"
           :to="currentPage === 2 ? '/blog/' : `/blog/page/${currentPage - 1}/`"
         >
-          Previous
+          ← Previous
         </nuxt-link>
         <span
           v-else
           class="custom-page-btn prev disabled"
         >
-          Previous
+          ← Previous
         </span>
         <div class="custom-pagination-center">
           <span v-for="item in paginationPages" :key="item.key">
@@ -54,13 +53,13 @@
           class="custom-page-btn next"
           :to="`/blog/page/${currentPage + 1}/`"
         >
-          Next
+          Next →
         </nuxt-link>
         <span
           v-else
           class="custom-page-btn next disabled"
         >
-          Next
+          Next →
         </span>
       </div>
     </nav>
@@ -244,23 +243,42 @@ watch(() => route.params.number, () => {
   }
 }
 .section__heading {
-  font-size: 32px;
-  margin-top: 32px;
+  font-size: clamp(22px, 2.4vw, 28px);
+  margin-top: 48px;
+  margin-bottom: 24px;
+}
+
+.blog-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-6);
+  margin-bottom: var(--space-8);
+}
+
+@media (max-width: 991px) {
+  .blog-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 600px) {
+  .blog-grid {
+    grid-template-columns: 1fr;
+  }
 }
 @media (max-width: 600px) {
   .section__heading {
-    font-size: 24px;
     margin-top: 24px;
   }
 }
 .custom-pagination-bar {
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
   width: 100%;
-  margin: 64px auto;
+  margin: 48px auto 64px;
   padding: 32px 0px;
-  border-top: 1px solid #eaecf0;
+  border-top: 1px solid var(--border-light);
   flex-wrap: wrap;
   gap: 12px;
 }
@@ -268,8 +286,7 @@ watch(() => route.params.number, () => {
   display: flex;
   justify-content: center;
   align-items: center;
-  flex: 1;
-  gap: 8px;
+  gap: 6px;
   flex-wrap: wrap;
 }
 
@@ -296,35 +313,46 @@ watch(() => route.params.number, () => {
   justify-content: center;
   text-decoration: none;
   background: #fff;
-  border-radius: 4px;
-  min-width: 44px;
+  border: 1px solid transparent;
+  border-radius: var(--r-full);
+  min-width: 40px;
   min-height: 40px;
-  font-weight: 600;
-  font-size: var(--ft-small-body);
-  color: var(--clr-text-secondary);
+  font-weight: var(--fw-semibold);
+  font-size: var(--fs-sm);
+  color: var(--fg-2);
   cursor: pointer;
   outline: none;
-  transition: background 0.2s, color 0.2s, border 0.2s;
-  padding: 0 16px;
+  transition: background 140ms ease, color 140ms ease, border-color 140ms ease;
+  padding: 0 14px;
 }
 
 .custom-page-btn:hover {
-  background: #f9fafb;
+  background: var(--bg-violet-25);
+  color: var(--violet-600);
 }
-.custom-page-btn.active,
+.custom-page-btn.active {
+  background: var(--violet-500);
+  border-color: var(--violet-500);
+  color: #fff;
+  cursor: default;
+}
 .custom-page-btn.disabled {
-  background: #f9fafb;
-  color: var(--clr-text-secondary);
-  border: 1px solid #d0d5dd;
+  background: var(--gray-50);
+  color: var(--fg-muted);
+  border: 1px solid var(--border-light);
   cursor: default;
 }
 .custom-page-btn.prev,
 .custom-page-btn.next {
-  border: 1px solid #d0d5dd;
-  min-width: 120px;
+  border: 1px solid var(--border-dark);
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 0 18px;
+}
+.custom-page-btn.next:not(.disabled):hover,
+.custom-page-btn.prev:not(.disabled):hover {
+  border-color: var(--violet-300);
 }
 .custom-page-btn.disabled {
   opacity: 1;

--- a/pages/preview.vue
+++ b/pages/preview.vue
@@ -6,7 +6,7 @@
     {{ fetchError.message || 'Failed to load draft' }}
   </div>
   <PageComponents v-else-if="components.length" :components="components" />
-  <div v-else-if="previewData?.type === 'blog' && blogData" class="container mw-920 blog-preview-container">
+  <div v-else-if="previewData?.type === 'blog' && blogData" class="blog-preview-container">
     <BlogPostView :blog-data="blogPostViewData" />
   </div>
   <div v-else style="padding: 4rem; text-align: center; color: #666">


### PR DESCRIPTION
## What

UI/UX revamp of the blog **listing** and **article** pages. No content or CMS changes — structure and style only.

### Listing (`/blog/`, `/blog/page/N/`)
- v2 card grid: fixed-ratio covers, equal-height cards, quieter date · read-time meta
- redesigned featured split card
- centered pill pagination (`← Previous · 1 2 … N · Next →`)
- consistent gutters + section spacing

### Article (`/blog/[slug]/`, shared with `/preview`)
- violet-wash hero band with avatar byline (author · date · read-time)
- sticky right rail: "On this page" TOC with scrollspy + sticky share rail
- mobile/tablet: TOC accordion + end-of-article share row
- thin reading-progress bar; refined body typography (lead paragraph, blockquotes, tables, code)
- Related Blogs grid rebuilt with real covers + meta
- new share icon components (X / LinkedIn / Facebook / copy-link)

## Notes
- Branched fresh off `master`; excludes unrelated in-flight work.
- `pages/preview.vue` updated so blog drafts render in the new full-bleed layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)