### PR TITLE
Template category V2 landing page

### DIFF
--- a/components/LucideIcon.vue
+++ b/components/LucideIcon.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script>
-import * as lucide from 'lucide-vue-next'
+import * as lucide from '@lucide/vue'
 
 // kebab-case ("file-check-2") -> PascalCase ("FileCheck2")
 function toPascal(name) {

--- a/components/LucideIcon.vue
+++ b/components/LucideIcon.vue
@@ -1,0 +1,32 @@
+<template>
+  <component :is="iconComponent" :size="size" :stroke-width="strokeWidth" :color="color" aria-hidden="true" />
+</template>
+
+<script>
+import * as lucide from 'lucide-vue-next'
+
+// kebab-case ("file-check-2") -> PascalCase ("FileCheck2")
+function toPascal(name) {
+  return String(name || '')
+    .split('-')
+    .filter(Boolean)
+    .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+    .join('')
+}
+
+export default {
+  name: 'LucideIcon',
+  props: {
+    name: { type: String, default: '' },
+    size: { type: [Number, String], default: 18 },
+    strokeWidth: { type: [Number, String], default: 2 },
+    color: { type: String, default: 'currentColor' },
+    fallback: { type: String, default: 'FileText' }, // used when name is empty/unknown
+  },
+  computed: {
+    iconComponent() {
+      return lucide[toPascal(this.name)] || lucide[this.fallback]
+    },
+  },
+}
+</script>

--- a/components/TemplateSection.vue
+++ b/components/TemplateSection.vue
@@ -12,8 +12,10 @@
           v-for="(template, idx) in templates"
           :key="idx"
           :template="template"
+          @preview="openPreview"
         />
       </div>
+      <TemplatePreviewModal :is-open="!!previewUrl" :survey-url="previewUrl || ''" @close="closePreview" />
       <div class="d-flex align-items-center justify-content-center mt-4">
         <NuxtLink :to="`/templates/`">
           <button class="btn-all-templates">More Templates</button>
@@ -25,7 +27,18 @@
 
 <script setup>
 import TemplateCard from './template/TemplateCard.vue'
+import TemplatePreviewModal from '@/components/v2/template/TemplatePreviewModal.vue'
 import { getRandomTemplates } from '@/utils/getTemplatesAndCategories'
+
+const previewUrl = ref(null)
+function openPreview(template) {
+  previewUrl.value = template.surveyUrl
+  document.body.style.overflow = 'hidden'
+}
+function closePreview() {
+  previewUrl.value = null
+  document.body.style.overflow = ''
+}
 
 const props = defineProps({
   slug: { type: String },

--- a/components/features/TemplateSection.vue
+++ b/components/features/TemplateSection.vue
@@ -12,8 +12,10 @@
           v-for="(template, idx) in templates"
           :key="idx"
           :template="template"
+          @preview="openPreview"
         />
       </div>
+      <TemplatePreviewModal :is-open="!!previewUrl" :survey-url="previewUrl || ''" @close="closePreview" />
       <div class="d-flex align-items-center justify-content-center mt-4">
         <NuxtLink :to="button.link">
           <button class="btn-all-templates">{{button.text}}</button>
@@ -25,7 +27,18 @@
 
 <script setup>
 import TemplateCard from '@/components/template/TemplateCard.vue'
+import TemplatePreviewModal from '@/components/v2/template/TemplatePreviewModal.vue'
 import { getRandomTemplates } from '@/utils/getTemplatesAndCategories'
+
+const previewUrl = ref(null)
+function openPreview(template) {
+  previewUrl.value = template.surveyUrl
+  document.body.style.overflow = 'hidden'
+}
+function closePreview() {
+  previewUrl.value = null
+  document.body.style.overflow = ''
+}
 
 const props = defineProps({
   slug: {

--- a/components/template/TemplateCard.vue
+++ b/components/template/TemplateCard.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="template">
-    <NuxtLink :to="`/templates/${template.slug}/`">
+  <div class="template fm-card">
+    <NuxtLink class="template__link" :to="`/templates/${template.slug}/`">
       <div class="template-image-wrapper">
         <div v-if="loading" class="image-skeleton"></div>
         <img
@@ -16,6 +16,9 @@
         />
       </div>
       <div class="template-content">
+        <div v-if="categoryName" class="template-meta">
+          <span class="template-meta__cat">{{ categoryName }}</span>
+        </div>
         <h3 class="template-name pointer">
           {{ template?.name }}
         </h3>
@@ -24,6 +27,14 @@
         </p>
       </div>
     </NuxtLink>
+    <div class="template-footer">
+      <button type="button" class="template-footer__preview" @click="onPreview">
+        <LucideIcon name="eye" :size="15" /> Preview
+      </button>
+      <button type="button" class="template-footer__use" @click="onUse">
+        Use template <LucideIcon name="arrow-right" :size="14" />
+      </button>
+    </div>
   </div>
 </template>
 
@@ -33,6 +44,10 @@ export default {
     template: {
       type: Object,
       required: true,
+    },
+    categoryLabel: {
+      type: String,
+      default: '',
     },
   },
   data() {
@@ -48,10 +63,24 @@ export default {
   },
   computed: {
     previewImageUrl() {
-      return (
-        this.template.previewImageUrl ||
-        '/templates/create_form.png'
-      )
+      return this.template.previewImageUrl || '/templates/create_form.png'
+    },
+    categoryName() {
+      return this.categoryLabel || this.template.category?.name || this.template.categories?.[0]?.name || ''
+    },
+  },
+  methods: {
+    // Preview the live form, same as the template detail page's preview.
+    onPreview() {
+      if (this.template.surveyUrl) {
+        window.open(this.template.surveyUrl, '_blank')
+      } else {
+        navigateTo(`/templates/${this.template.slug}/`)
+      }
+    },
+    // Use the template — same redirect the detail page's CTA uses.
+    onUse() {
+      window.open(`https://app.formester.com/templates?template_id=${this.template.id}`, '_blank')
     },
   },
 }
@@ -59,41 +88,117 @@ export default {
 
 <style scoped>
 .template {
-  transition: all 500ms ease;
-  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  transition: box-shadow 140ms ease, border-color 140ms ease, transform 140ms ease;
+  border-radius: 14px;
   border: 1px solid var(--Stroke, #eaecf0);
   background: var(--Base-White, #fff);
-  box-shadow: 0px 4px 8px -2px rgba(16, 24, 40, 0.1),
-    0px 2px 4px -2px rgba(16, 24, 40, 0.06);
-  min-height: 130px;
+  box-shadow: 0 1px 2px 0 rgba(16, 24, 40, 0.05);
   overflow: hidden;
 }
 
-.template:hover .template-preview__img {
-  transform: scale(1.05);
+.template:hover {
+  box-shadow: 0 8px 24px -6px rgba(16, 24, 40, 0.12), 0 2px 6px -2px rgba(16, 24, 40, 0.06);
+  transform: translateY(-2px);
 }
+
+.template:hover .template-preview__img {
+  transform: scale(1.04);
+}
+
+.template__link {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  color: inherit;
+  text-decoration: none;
+}
+
 .template-content {
   padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  flex: 1;
 }
+
+.template-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: #697586;
+}
+
+.template-meta__cat {
+  font-weight: 600;
+  color: #475467;
+  text-transform: capitalize;
+}
+
 .template-name {
   user-select: none;
-  color: var(--neutral-900, #171717);
-  font-size: 16px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 24px;
+  margin: 0;
+  color: #101828;
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 22px;
 }
+
 .template-description {
   margin: 0;
-  color: var(--neutral-600, #525252);
-  font-size: 12px;
+  color: #475467;
+  font-size: 13px;
   font-weight: 400;
-  line-height: 18px;
+  line-height: 20px;
   display: -webkit-box;
-  -webkit-line-clamp: 3;
+  -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.template-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-top: 1px solid #f2f4f7;
+}
+
+.template-footer__preview,
+.template-footer__use {
+  display: inline-flex;
+  align-items: center;
+  background: none;
+  border: none;
+  padding: 4px 2px;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.template-footer__preview {
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #475467;
+}
+
+.template-footer__preview:hover {
+  color: #101828;
+}
+
+.template-footer__use {
+  gap: 5px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #6941c6;
+}
+
+.template-footer__use:hover,
+.template:hover .template-footer__use {
+  color: #53389e;
 }
 
 .template-image-wrapper {
@@ -103,7 +208,6 @@ export default {
 .image-skeleton {
   position: absolute;
   inset: 0;
-  border-radius: 8px;
   animation: skeleton-loading 1s linear infinite alternate;
   z-index: 1;
 }

--- a/components/template/TemplateCard.vue
+++ b/components/template/TemplateCard.vue
@@ -50,6 +50,7 @@ export default {
       default: '',
     },
   },
+  emits: ['preview'],
   data() {
     return {
       loading: true,
@@ -70,10 +71,10 @@ export default {
     },
   },
   methods: {
-    // Preview the live form, same as the template detail page's preview.
+    // Preview the live form — the parent grid opens the shared preview modal.
     onPreview() {
       if (this.template.surveyUrl) {
-        window.open(this.template.surveyUrl, '_blank')
+        this.$emit('preview', this.template)
       } else {
         navigateTo(`/templates/${this.template.slug}/`)
       }

--- a/components/template/TemplateCategories.vue
+++ b/components/template/TemplateCategories.vue
@@ -184,7 +184,7 @@ export default {
 }
 
 /* ── Category search (reuses the shared TemplateSearch for a consistent
-   pill + focus ring; override its min-width so it fits the narrow sidebar). ── */
+   box + focus ring; override its min-width so it fits the narrow sidebar). ── */
 .category-search {
   margin: 12px 0 18px;
 }

--- a/components/template/TemplateCategories.vue
+++ b/components/template/TemplateCategories.vue
@@ -196,7 +196,7 @@ export default {
   display: none;
 }
 
-@media only screen and (max-width: 840px) {
+@media only screen and (max-width: 900px) {
   .category-bar {
     display: flex;
     justify-content: space-between;

--- a/components/template/TemplateCategories.vue
+++ b/components/template/TemplateCategories.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="template-categories">
-    <!-- Category bar for small devices to show hide categories -->
+    <!-- Category bar for small devices to show/hide categories -->
     <div class="category-bar" @click="showCategories = !showCategories">
       <span class="our-template-heading">Our Templates</span>
       <nuxt-img
@@ -17,126 +17,71 @@
       />
     </div>
 
-    <NuxtLink
-      to="/templates/"
-    >
-      <h2
-        class="all-category-heading"
-        :class="{
-          'd-none': !showCategories && isMobile,
-        }"
-      >
+    <NuxtLink to="/templates/">
+      <h2 class="all-category-heading" :class="{ 'd-none': !showCategories && isMobile }">
+        <LucideIcon name="layout-grid" :size="17" class="all-category-heading__icon" />
         All Templates
       </h2>
     </NuxtLink>
 
-    <div
-      class="category-search"
-      :class="{ 'd-none': !showCategories && isMobile }"
-    >
-      <img class="category-search__icon" src="~/assets/images/icons/chevron-right.svg" alt="" aria-hidden="true" />
-      <input
-        v-model="search"
-        class="category-search__input"
-        type="text"
-        placeholder="Search categories"
-        aria-label="Search categories"
-      />
+    <div class="category-search" :class="{ 'd-none': !showCategories && isMobile }">
+      <TemplateSearch placeholder="Search categories" @searchInput="search = $event" />
     </div>
 
-    <div
-      v-for="(categories, categoryType) in filteredCategories"
-      :key="categoryType"
-      class="category-block"
-      :class="{ 'd-none': !showCategories && isMobile }"
-    >
-      <div @click="toggleCollapse(categoryType)">
-        <div
-          class="categoryType-container d-flex align-items-center justify-content-between"
-        >
-          <h2 class="category-heading pointer">{{ formatCategoryHeading(categoryType) }}</h2>
-          <div>
-            <nuxt-img
-              class="collapse-arrow-btn pointer"
-              :class="{ 'rotate-arrow': isExpanded[categoryType] }"
-              src="templates/collapseDown-arrow.svg"
-              alt="category-arrow-button"
-            />
-          </div>
-        </div>
-      </div>
-      <div
-        class="categories"
-        :id="'categories' + categoryType"
-        :class="{ 'categories-collapsed': !isExpanded[categoryType] && !search.trim() }"
-      >
+    <div class="category-list" :class="{ 'd-none': !showCategories && isMobile }">
+      <div v-for="group in groupedCategories" :key="group.kind" class="category-group">
+        <div class="by-category-label">{{ group.label }}</div>
         <NuxtLink
-          v-for="category in categories"
+          v-for="category in group.items"
           :key="category.id"
           :to="`/templates/categories/${category.slug}/`"
         >
-          <h3
-            class="category"
-            :class="{ active: activeCategory?.slug === category.slug }"
-          >
+          <h3 class="category" :class="{ active: activeCategory?.slug === category.slug }">
+            <LucideIcon :name="category.icon" :size="17" class="category__icon" />
             <span class="category__name">{{ category.name }}</span>
             <span v-if="category.templateCount" class="category__count">{{ category.templateCount }}</span>
           </h3>
         </NuxtLink>
       </div>
+      <p v-if="!groupedCategories.length" class="category-empty">No categories found</p>
     </div>
   </div>
 </template>
 
 <script>
+// Kind groups, in display order, each with its uppercase eyebrow label.
+const KIND_ORDER = ['purpose', 'department', 'industry', 'pdfTemplates']
+const KIND_LABELS = {
+  purpose: 'BY PURPOSE',
+  department: 'BY DEPARTMENT',
+  industry: 'BY INDUSTRY',
+  pdfTemplates: 'PDF TEMPLATES',
+}
+
 export default {
   props: ['activeCategory', 'templateCategories'],
   data() {
     return {
       showCategories: true,
-      isExpanded: this.initializeExpandedState(),
       isMobile: false,
       search: '',
     }
   },
   computed: {
-    // Filter categories by name; drop kinds with no matches. Empty search = all.
-    filteredCategories() {
+    // Grouped by kind (purpose → department → industry → pdf), each an
+    // alphabetically-sorted list, filtered by the search box; empty kinds dropped.
+    groupedCategories() {
       const term = this.search.trim().toLowerCase()
-      if (!term) return this.templateCategories || {}
-      const result = {}
-      Object.entries(this.templateCategories || {}).forEach(([kind, cats]) => {
-        const matched = (cats || []).filter((c) => c.name?.toLowerCase().includes(term))
-        if (matched.length) result[kind] = matched
-      })
-      return result
+      const src = this.templateCategories || {}
+      return KIND_ORDER.map((kind) => {
+        let items = src[kind] || []
+        if (term) items = items.filter((c) => c.name?.toLowerCase().includes(term))
+        items = [...items].sort((a, b) => (a.name || '').localeCompare(b.name || ''))
+        return { kind, label: KIND_LABELS[kind], items }
+      }).filter((g) => g.items.length)
     },
   },
   methods: {
-    initializeExpandedState() {
-      // For SSR: expand all categories by default for SEO
-      const allExpanded = {}
-      if (this.templateCategories) {
-        Object.keys(this.templateCategories).forEach(key => {
-          allExpanded[key] = true
-        })
-      }
-      return allExpanded
-    },
-    formatCategoryHeading(str) {
-      if (!str) return '';
-      // Insert space before all caps and replace underscores with space
-      let formatted = str.replace(/([a-z])([A-Z])/g, '$1 $2').replace(/_/g, ' ');
-      // Replace any occurrence of 'Pdf' (case-insensitive) with 'PDF'
-      return formatted.replace(/Pdf/gi, 'PDF');
-    },
-    toggleCollapse(categoryType) {
-      this.isExpanded[categoryType] = !this.isExpanded[categoryType]
-      localStorage.setItem('isCollapsedState', JSON.stringify(this.isExpanded))
-    },
-    clearIsExpandedState() {
-      localStorage.removeItem('isCollapsedState')
-    },
     handleResize() {
       this.isMobile = window.innerWidth <= 840
     },
@@ -146,27 +91,10 @@ export default {
       this.handleResize()
       this.showCategories = !this.isMobile
       window.addEventListener('resize', this.handleResize)
-
-      // On client-side, apply saved state or collapse all except first
-      const savedState = localStorage.getItem('isCollapsedState')
-      if (savedState) {
-        this.isExpanded = JSON.parse(savedState)
-      } else {
-        // Collapse all except first category after initial render
-        const collapsedState = {}
-        Object.keys(this.templateCategories).forEach((key, index) => {
-          collapsedState[key] = index === 0
-        })
-        this.isExpanded = collapsedState
-      }
-
-      window.addEventListener('beforeunload', this.clearIsExpandedState)
     }
   },
   beforeDestroy() {
-    // Remove the event listener when the component is destroyed
     window.removeEventListener('resize', this.handleResize)
-    window.removeEventListener('beforeunload', this.clearIsExpandedState)
   },
 }
 </script>
@@ -181,114 +109,91 @@ export default {
   display: none;
 }
 .all-category-heading {
-  color: var(--neutral-900, #404040);
-  padding: 8px 36px 8px 0;
+  color: var(--neutral-900, #101828);
+  padding: 8px 10px;
   cursor: pointer;
-  font-size: 16px;
+  font-size: 14px;
   line-height: 24px;
   user-select: none;
-  font-weight: 500;
-  letter-spacing: 0em;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
 }
-.category-block {
-  margin-top: 16px;
+.all-category-heading__icon {
+  color: var(--clr-primary, #7f56d9);
 }
-h2::first-letter {
-  text-transform: uppercase;
+
+/* ── BY CATEGORY list ── */
+.by-category-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: #98a2b3;
+  padding: 0 10px 8px;
 }
-.category-heading {
-  color: var(--neutral-700, #404040);
-  padding: 8px 0;
-  margin: 0;
-  font-size: 16px;
-  font-weight: 500 !important;
-  line-height: 24px;
-  letter-spacing: 0em;
-  text-align: left;
-  text-transform: capitalize;
+.category-list {
+  margin-top: 6px;
 }
-.categoryType-container {
-  padding-right: 35px;
-}
-.category-menu-btn {
-  display: none;
+.category-group {
+  margin-bottom: 16px;
 }
 .category {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  padding: 6px 10px;
+  gap: 10px;
+  padding: 8px 10px;
   cursor: pointer;
   font-size: 14px;
-  line-height: 24px;
-  color: #272727;
+  line-height: 20px;
+  color: #344054;
   user-select: none;
   margin-bottom: 2px;
-  font-weight: 400;
+  font-weight: 500;
   border-radius: 8px;
   transition: background 0.15s, color 0.15s;
 }
 .category.active {
-  color: #4f3895;
+  color: #53389e;
   font-weight: 600;
   background: var(--background-color-violet-25, #f7f3ff);
 }
 .category:hover {
-  color: #643ed6;
+  color: #101828;
   background: var(--background-color-grey-50, #f9fafb);
+}
+.category__name {
+  flex: 1;
 }
 .category__count {
   font-size: 12px;
   color: #98a2b3;
   flex-shrink: 0;
 }
-
-/* ── Category search ── */
-.category-search {
-  position: relative;
-  margin: 12px 0 8px;
+.category__icon {
+  flex-shrink: 0;
+  color: #667085;
 }
-.category-search__icon {
-  position: absolute;
-  left: 10px;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 13px;
-  height: 13px;
-  opacity: 0.4;
+.category.active .category__icon {
+  color: #53389e;
 }
-.category-search__input {
-  width: 100%;
-  box-sizing: border-box;
-  padding: 8px 10px 8px 30px;
+.category-empty {
+  padding: 8px 10px;
   font-size: 13px;
-  color: var(--clr-text-secondary, #475467);
-  border: 1px solid var(--clr-border, #d0d5dd);
-  border-radius: 8px;
-  outline: none;
-  background: #fff;
-}
-.category-search__input:focus {
-  border-color: var(--clr-primary, #7f56d9);
-}
-.collapse-arrow-btn {
-  transition: all 0.3s ease-in-out;
-}
-.rotate-arrow {
-  transform: rotate(180deg);
-  transition: all 0.3s ease-in-out;
+  color: #98a2b3;
 }
 
-.categories {
-  max-height: 2000px; /* Large enough to fit all categories */
-  overflow: visible;
-  transition: max-height 0.3s ease;
+/* ── Category search (reuses the shared TemplateSearch for a consistent
+   pill + focus ring; override its min-width so it fits the narrow sidebar). ── */
+.category-search {
+  margin: 12px 0 18px;
+}
+.category-search :deep(.search-box) {
+  min-width: 0;
 }
 
-.categories-collapsed {
-  max-height: 0;
-  overflow: hidden;
+.category-menu-btn {
+  display: none;
 }
 
 @media only screen and (max-width: 840px) {
@@ -301,19 +206,8 @@ h2::first-letter {
     border-radius: 12px;
     background: var(--neutral-100, #f5f5f5);
   }
-  .sidebar-heading {
-    display: none;
-  }
   .our-template-heading {
     display: block;
-  }
-  .category-heading {
-    color: var(--neutral-900, #171717);
-    padding: 0;
-    margin: 0;
-    font-size: 14px;
-    font-weight: 400;
-    line-height: 21px;
   }
   .category-menu-btn {
     display: flex;
@@ -321,20 +215,12 @@ h2::first-letter {
     justify-content: center;
   }
   .all-category-heading {
-    color: var(--neutral-900, #171717);
-    padding: 4px 8px 4px 8px;
+    padding: 4px 8px;
     font-size: 14px;
-    font-weight: 400;
-    line-height: 21px;
-    transition: none;
-  }
-  .categoryType-container {
-    padding: 0 8px 4px 8px;
+    font-weight: 600;
   }
   .category {
-    padding: 4px 8px 4px 8px;
-    font-weight: 400;
-    line-height: 21px;
+    padding: 6px 8px;
     transition: none;
   }
 }

--- a/components/template/TemplateCategories.vue
+++ b/components/template/TemplateCategories.vue
@@ -29,8 +29,23 @@
         All Templates
       </h2>
     </NuxtLink>
+
     <div
-      v-for="(categories, categoryType) in templateCategories"
+      class="category-search"
+      :class="{ 'd-none': !showCategories && isMobile }"
+    >
+      <img class="category-search__icon" src="~/assets/images/icons/chevron-right.svg" alt="" aria-hidden="true" />
+      <input
+        v-model="search"
+        class="category-search__input"
+        type="text"
+        placeholder="Search categories"
+        aria-label="Search categories"
+      />
+    </div>
+
+    <div
+      v-for="(categories, categoryType) in filteredCategories"
       :key="categoryType"
       class="category-block"
       :class="{ 'd-none': !showCategories && isMobile }"
@@ -53,7 +68,7 @@
       <div
         class="categories"
         :id="'categories' + categoryType"
-        :class="{ 'categories-collapsed': !isExpanded[categoryType] }"
+        :class="{ 'categories-collapsed': !isExpanded[categoryType] && !search.trim() }"
       >
         <NuxtLink
           v-for="category in categories"
@@ -64,7 +79,8 @@
             class="category"
             :class="{ active: activeCategory?.slug === category.slug }"
           >
-            {{ category.name }}
+            <span class="category__name">{{ category.name }}</span>
+            <span v-if="category.templateCount" class="category__count">{{ category.templateCount }}</span>
           </h3>
         </NuxtLink>
       </div>
@@ -80,7 +96,21 @@ export default {
       showCategories: true,
       isExpanded: this.initializeExpandedState(),
       isMobile: false,
+      search: '',
     }
+  },
+  computed: {
+    // Filter categories by name; drop kinds with no matches. Empty search = all.
+    filteredCategories() {
+      const term = this.search.trim().toLowerCase()
+      if (!term) return this.templateCategories || {}
+      const result = {}
+      Object.entries(this.templateCategories || {}).forEach(([kind, cats]) => {
+        const matched = (cats || []).filter((c) => c.name?.toLowerCase().includes(term))
+        if (matched.length) result[kind] = matched
+      })
+      return result
+    },
   },
   methods: {
     initializeExpandedState() {
@@ -184,21 +214,63 @@ h2::first-letter {
   display: none;
 }
 .category {
-  padding: 4px 36px 4px 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 10px;
   cursor: pointer;
   font-size: 14px;
   line-height: 24px;
   color: #272727;
   user-select: none;
-  margin-bottom: 4px;
+  margin-bottom: 2px;
   font-weight: 400;
+  border-radius: 8px;
+  transition: background 0.15s, color 0.15s;
 }
 .category.active {
   color: #4f3895;
   font-weight: 600;
+  background: var(--background-color-violet-25, #f7f3ff);
 }
 .category:hover {
   color: #643ed6;
+  background: var(--background-color-grey-50, #f9fafb);
+}
+.category__count {
+  font-size: 12px;
+  color: #98a2b3;
+  flex-shrink: 0;
+}
+
+/* ── Category search ── */
+.category-search {
+  position: relative;
+  margin: 12px 0 8px;
+}
+.category-search__icon {
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 13px;
+  height: 13px;
+  opacity: 0.4;
+}
+.category-search__input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 8px 10px 8px 30px;
+  font-size: 13px;
+  color: var(--clr-text-secondary, #475467);
+  border: 1px solid var(--clr-border, #d0d5dd);
+  border-radius: 8px;
+  outline: none;
+  background: #fff;
+}
+.category-search__input:focus {
+  border-color: var(--clr-primary, #7f56d9);
 }
 .collapse-arrow-btn {
   transition: all 0.3s ease-in-out;

--- a/components/template/TemplateSearch.vue
+++ b/components/template/TemplateSearch.vue
@@ -35,14 +35,17 @@ defineProps({
 })
 
 const searchTerm = ref('')
+let debounceTimer = null
 
 function resetSearchInput() {
   searchTerm.value = ''
+  clearTimeout(debounceTimer)
   emit('searchInput', '')
 }
 
 function emitSearchTerm() {
-  emit('searchInput', searchTerm.value)
+  clearTimeout(debounceTimer)
+  debounceTimer = setTimeout(() => emit('searchInput', searchTerm.value), 250)
 }
 </script>
 

--- a/components/template/TemplateSearch.vue
+++ b/components/template/TemplateSearch.vue
@@ -55,7 +55,7 @@ function emitSearchTerm() {
   align-items: center;
   background: var(--bg-primary);
   border: 1px solid var(--border-light);
-  border-radius: 40px;
+  border-radius: 8px;
   padding: var(--space-3) var(--space-4);
   box-shadow: var(--shadow-xs);
   transition: box-shadow 0.15s ease, border-color 0.15s ease;

--- a/components/template/TemplateSearch.vue
+++ b/components/template/TemplateSearch.vue
@@ -4,7 +4,7 @@
       <img class="search-icon" src="/templates/search.svg" alt="" aria-hidden="true" width="18" height="18" />
       <input
         type="text"
-        placeholder="Blood donation, job applicant tracker"
+        :placeholder="placeholder"
         v-model="searchTerm"
         @input="emitSearchTerm"
         class="search-input"
@@ -26,6 +26,13 @@
 
 <script setup>
 const emit = defineEmits(['searchInput'])
+
+defineProps({
+  placeholder: {
+    type: String,
+    default: 'Blood donation, job applicant tracker',
+  },
+})
 
 const searchTerm = ref('')
 

--- a/components/template/TemplateSearch.vue
+++ b/components/template/TemplateSearch.vue
@@ -120,7 +120,7 @@ function emitSearchTerm() {
   background: var(--gray-200);
 }
 
-@media (max-width: 840px) {
+@media (max-width: 900px) {
   .search-box {
     max-width: 100%;
     width: 100%;

--- a/components/template/Templates.vue
+++ b/components/template/Templates.vue
@@ -17,9 +17,6 @@
         <!-- HERO -->
         <div class="hero-wrap" :class="{ 'hero-wrap--v2': isV2 && activeCategory }">
           <div class="hero-left">
-            <div v-if="activeCategory && heroBadge" class="hero-badge">
-              <LucideIcon name="sparkles" :size="13" /> {{ heroBadge }}
-            </div>
             <div class="heading-row">
               <h1 class="content-heading" :class="{ 'content-heading--v2': isV2 && pageContent.heroTitle }">
                 <template v-if="isV2 && pageContent.heroTitle"
@@ -34,14 +31,8 @@
               </h1>
             </div>
             <p v-if="isV2 && pageContent.heroSubtitle" class="hero-subtitle">{{ pageContent.heroSubtitle }}</p>
-            <div v-if="!isV2 && activeCategory?.description" class="my-2">
-              <div
-                class="description-wrapper"
-                :class="{
-                  expanded: showFullDescription,
-                  'description-truncated': isClient && !showFullDescription,
-                }"
-              >
+            <div v-if="!hasHeroContent && activeCategory?.description" class="my-2">
+              <div class="description-wrapper" :class="{ 'description-truncated': isClient }">
                 <div class="content-description mt-0 mb-1" v-html="activeCategory.description" />
               </div>
               <button v-if="isClient" class="content-description-handle-button text-nowrap" @click="toggleDescription">
@@ -49,8 +40,8 @@
               </button>
             </div>
 
-            <!-- Hero actions + derivable stats -->
-            <div v-if="isV2 && activeCategory && !searchActive" class="hero-meta">
+            <!-- Hero actions + derivable stats (only once hero content is curated) -->
+            <div v-if="hasHeroContent && activeCategory && !searchActive" class="hero-meta">
               <div class="hero-actions">
                 <a href="/users/sign_up" class="hero-btn hero-btn--primary">Create form</a>
                 <NuxtLink to="/templates/" class="hero-btn hero-btn--ghost">Browse templates</NuxtLink>
@@ -76,7 +67,7 @@
             <div class="art-card art-card--amber"><span class="art-chip art-chip--amber"><LucideIcon name="search" :size="19" /></span></div>
             <div class="art-card art-card--red"><span class="art-chip art-chip--red"><LucideIcon name="activity" :size="19" /></span></div>
             <div class="art-card art-card--blue">
-              <span class="art-chip art-chip--blue"><LucideIcon name="user-check" :size="24" /></span>
+              <span class="art-chip art-chip--blue"><LucideIcon :name="activeCategory.icon || 'user-check'" :size="24" /></span>
               <span class="art-card__label">{{ activeCategory.name }}</span>
             </div>
             <div class="art-float">
@@ -90,9 +81,23 @@
           </div>
         </div>
 
+        <!-- Full description, expanded from the hero's Show more (default view only) -->
+        <div
+          v-if="!hasHeroContent && showFullDescription && activeCategory?.description"
+          class="description-expanded"
+        >
+          <div class="description-wrapper">
+            <div class="content-description mt-0 mb-1" v-html="activeCategory.description" />
+          </div>
+          <button class="content-description-handle-button text-nowrap" @click="toggleDescription">Show less</button>
+        </div>
+
         <!-- FILTER BAR (V2): search + sub-category pills -->
         <div v-if="isV2 && activeCategory" class="filter-bar">
-          <div class="filter-bar__search">
+          <div
+            class="filter-bar__search"
+            :class="{ 'filter-bar__search--wide': searchActive || !subcategories.length }"
+          >
             <TemplateSearch
               :placeholder="`Search ${categoryTemplateCount} ${activeCategory.name} templates`"
               @searchInput="handleSearch"
@@ -314,8 +319,15 @@ export default {
     searchActive() {
       return this.searchTerm.trim().length > 0
     },
+    // Every category page uses the V2 layout; the all-templates page
+    // (no activeCategory) keeps the flat grid.
     isV2() {
-      return !!this.activeCategory?.v2Enabled
+      return !!this.activeCategory
+    },
+    // No curated hero copy yet => "default view": description + Show more
+    // instead of CTAs/stats.
+    hasHeroContent() {
+      return !!(this.pageContent.heroTitle || this.pageContent.heroSubtitle)
     },
     pageContent() {
       return this.activeCategory?.pageContent || {}
@@ -360,15 +372,6 @@ export default {
     },
     categoryTemplateCount() {
       return this.activeCategory?.templateCount || this.allCategoryTemplates.length
-    },
-    heroBadge() {
-      const count = this.categoryTemplateCount
-      if (!count) return ''
-      const updated = this.activeCategory?.updatedAt
-      const when = updated
-        ? new Date(updated).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
-        : ''
-      return when ? `${count} templates · Updated ${when}` : `${count} templates`
     },
     // Templates + Free are derivable; forms-shipped / setup are admin-entered
     // (blank => omitted, so we never invent numbers).
@@ -528,9 +531,13 @@ export default {
   overflow: hidden;
 }
 
-.description-wrapper.expanded {
-  max-height: none;
-  overflow: visible;
+/* Full description, expanded below the hero so the hero layout never jumps. */
+.description-expanded {
+  background: var(--background-color-grey-50, #f9fafb);
+  border: 1px solid var(--clr-border, #eaecf0);
+  border-radius: 12px;
+  padding: 20px 24px;
+  margin: 8px 0 16px;
 }
 
 .description-wrapper .content-description {
@@ -747,8 +754,16 @@ export default {
   color: #fff;
   font-size: 14px;
   font-weight: 600;
+  line-height: 1.3;
   text-align: center;
   text-transform: capitalize;
+  padding: 0 6px;
+  max-width: 100%;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: break-word;
 }
 
 .art-float {
@@ -826,6 +841,12 @@ export default {
   max-width: 280px;
 }
 
+/* No sub-category pills sharing the row => give search the space. */
+.filter-bar__search--wide {
+  flex: 1 1 auto;
+  max-width: 560px;
+}
+
 /* Compact the shared search box inside the filter bar. */
 .filter-bar__search :deep(.search-box) {
   min-width: 0;
@@ -858,21 +879,7 @@ export default {
   border-radius: 4px;
 }
 
-/* ── Hero badge + actions + stats ── */
-.hero-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--clr-primary);
-  background: var(--background-color-violet-25, #f7f3ff);
-  border: 1px solid #ece3ff;
-  padding: 5px 11px;
-  border-radius: 9999px;
-  margin-bottom: 12px;
-}
-
+/* ── Hero actions + stats ── */
 .hero-meta {
   display: flex;
   flex-wrap: wrap;

--- a/components/template/Templates.vue
+++ b/components/template/Templates.vue
@@ -2,86 +2,172 @@
   <div>
     <div class="container template-container d-flex">
       <div class="content-wrapper w-100">
-        <div class="search-row">
+        <!-- Top search: non-V2 only (V2 moves it into the filter bar) -->
+        <div v-if="!isV2" class="search-row">
           <TemplateSearch @searchInput="handleSearch" />
         </div>
         <div v-if="activeCategory" class="breadcrumb d-flex align-items-center gap-2">
-          <NuxtLink to="/templates/" class="breadcrumb-text"> All Templates </NuxtLink>
-          <img src="~/assets/images/icons/chevron-right.svg" />
+          <NuxtLink to="/" class="breadcrumb-text">Home</NuxtLink>
+          <LucideIcon name="chevron-right" :size="13" class="breadcrumb-sep" />
+          <NuxtLink to="/templates/" class="breadcrumb-text">Templates</NuxtLink>
+          <LucideIcon name="chevron-right" :size="13" class="breadcrumb-sep" />
           <span class="breadcrumb-current">{{ activeCategory.name }}</span>
         </div>
-        <div v-if="activeCategory && heroBadge" class="hero-badge">{{ heroBadge }}</div>
-        <div class="heading-row">
-          <h1 class="content-heading">
-            {{ activeCategory ? activeCategory.name : 'All' }}
-            Templates
-          </h1>
-        </div>
-        <div v-if="activeCategory?.description" class="my-2">
-          <div
-            class="description-wrapper"
-            :class="{
-              expanded: showFullDescription,
-              'description-truncated': isClient && !showFullDescription,
-            }"
-          >
-            <div class="content-description mt-0 mb-1" v-html="activeCategory.description" />
-          </div>
-          <button v-if="isClient" class="content-description-handle-button text-nowrap" @click="toggleDescription">
-            {{ descriptionButtonLabel }}
-          </button>
-        </div>
 
-        <!-- Hero actions + derivable stats -->
-        <div v-if="activeCategory && !searchActive" class="hero-meta">
-          <div class="hero-actions">
-            <a href="/users/sign_up" class="hero-btn hero-btn--primary">Create form</a>
-            <NuxtLink to="/templates/" class="hero-btn hero-btn--ghost">Browse templates</NuxtLink>
-          </div>
-          <div v-if="heroStats.length" class="hero-stats">
-            <div v-for="stat in heroStats" :key="stat.label" class="hero-stat">
-              <span class="hero-stat__value">{{ stat.value }}</span>
-              <span class="hero-stat__label">{{ stat.label }}</span>
+        <!-- HERO -->
+        <div class="hero-wrap" :class="{ 'hero-wrap--v2': isV2 && activeCategory }">
+          <div class="hero-left">
+            <div v-if="activeCategory && heroBadge" class="hero-badge">
+              <LucideIcon name="sparkles" :size="13" /> {{ heroBadge }}
+            </div>
+            <div class="heading-row">
+              <h1 class="content-heading" :class="{ 'content-heading--v2': isV2 && pageContent.heroTitle }">
+                <template v-if="isV2 && pageContent.heroTitle"
+                  ><span
+                    v-for="(tok, i) in heroTitleTokens"
+                    :key="i"
+                    :class="{ 'hero-highlight': tok.highlight }"
+                    >{{ tok.text }}</span
+                  ></template
+                >
+                <template v-else>{{ activeCategory ? activeCategory.name : 'All' }} Templates</template>
+              </h1>
+            </div>
+            <p v-if="isV2 && pageContent.heroSubtitle" class="hero-subtitle">{{ pageContent.heroSubtitle }}</p>
+            <div v-if="!isV2 && activeCategory?.description" class="my-2">
+              <div
+                class="description-wrapper"
+                :class="{
+                  expanded: showFullDescription,
+                  'description-truncated': isClient && !showFullDescription,
+                }"
+              >
+                <div class="content-description mt-0 mb-1" v-html="activeCategory.description" />
+              </div>
+              <button v-if="isClient" class="content-description-handle-button text-nowrap" @click="toggleDescription">
+                {{ descriptionButtonLabel }}
+              </button>
+            </div>
+
+            <!-- Hero actions + derivable stats -->
+            <div v-if="isV2 && activeCategory && !searchActive" class="hero-meta">
+              <div class="hero-actions">
+                <a href="/users/sign_up" class="hero-btn hero-btn--primary">Create form</a>
+                <NuxtLink to="/templates/" class="hero-btn hero-btn--ghost">Browse templates</NuxtLink>
+              </div>
+              <div v-if="heroStats.length" class="hero-stats">
+                <div v-for="stat in heroStats" :key="stat.label" class="hero-stat">
+                  <span class="hero-stat__value">{{ stat.value }}</span>
+                  <span class="hero-stat__label">{{ stat.label }}</span>
+                </div>
+              </div>
             </div>
           </div>
+
+          <!-- Admin-authored hero side asset (HTML blocks), when provided -->
+          <div
+            v-if="isV2 && activeCategory && heroArtBlocks.length"
+            class="hero-art hero-art--custom"
+          >
+            <StrapiRawHtml v-for="(block, i) in heroArtBlocks" :key="i" :markup="block.content" />
+          </div>
+          <!-- Default decorative card-stack art (V2, desktop only) -->
+          <div v-else-if="isV2 && activeCategory" class="hero-art" aria-hidden="true">
+            <div class="art-card art-card--amber"><span class="art-chip art-chip--amber"><LucideIcon name="search" :size="19" /></span></div>
+            <div class="art-card art-card--red"><span class="art-chip art-chip--red"><LucideIcon name="activity" :size="19" /></span></div>
+            <div class="art-card art-card--blue">
+              <span class="art-chip art-chip--blue"><LucideIcon name="user-check" :size="24" /></span>
+              <span class="art-card__label">{{ activeCategory.name }}</span>
+            </div>
+            <div class="art-float">
+              <span class="art-float__chip"><LucideIcon name="file-check-2" :size="16" /></span>
+              <div class="art-float__text">
+                <span class="art-float__title">{{ categoryTemplateCount }} templates</span>
+                <span class="art-float__sub">Ready to ship</span>
+              </div>
+            </div>
+            <div class="art-pill"><LucideIcon name="badge-check" :size="14" /> E-signed &amp; audited</div>
+          </div>
         </div>
 
-        <!-- Sub-category quick-filter tabs -->
-        <div v-if="!searchActive && subcategories.length" class="subcat-tabs">
-          <a v-for="sub in subcategories" :key="sub.id" class="subcat-tab" :href="`#subcat-${sub.slug}`">
-            {{ sub.name }}
-            <span class="subcat-tab__count">{{ sub.templates.length }}</span>
-          </a>
+        <!-- FILTER BAR (V2): search + sub-category pills -->
+        <div v-if="isV2 && activeCategory" class="filter-bar">
+          <div class="filter-bar__search">
+            <TemplateSearch
+              :placeholder="`Search ${categoryTemplateCount} ${activeCategory.name} templates`"
+              @searchInput="handleSearch"
+            />
+          </div>
+          <div v-if="!searchActive && subcategories.length" class="subcat-tabs">
+            <button
+              type="button"
+              class="subcat-tab"
+              :class="{ 'subcat-tab--active': !activeFilter }"
+              @click="activeFilter = null"
+            >
+              All
+              <span class="subcat-tab__count">{{ categoryTemplateCount }}</span>
+            </button>
+            <button
+              v-for="sub in subcategories"
+              :key="sub.id"
+              type="button"
+              class="subcat-tab"
+              :class="{ 'subcat-tab--active': activeFilter === sub.slug }"
+              @click="activeFilter = sub.slug"
+            >
+              {{ shortSubName(sub) }}
+            </button>
+          </div>
         </div>
 
         <!-- Featured templates -->
-        <section v-if="!searchActive && featuredTemplates.length" class="cat-section" aria-label="Featured templates">
+        <section
+          v-if="isV2 && !searchActive && !activeFilter && featuredTemplates.length"
+          class="cat-section"
+          aria-label="Featured templates"
+        >
           <div class="section-eyebrow">FEATURED</div>
-          <h2 class="section-title">Most popular {{ activeCategory.name }} templates</h2>
+          <h2 class="section-title">{{ featuredTitle }}</h2>
+          <p v-if="featuredSubtitle" class="section-subtitle">{{ featuredSubtitle }}</p>
           <div class="templates-grid">
-            <TemplateCard v-for="template in featuredTemplates" :key="`featured-${template.id}`" :template="template" />
+            <TemplateCard
+              v-for="template in featuredTemplates"
+              :key="`featured-${template.id}`"
+              :template="template"
+              :category-label="activeCategory.name"
+            />
           </div>
         </section>
 
         <!-- Sub-category sections -->
-        <template v-if="!searchActive && subcategories.length">
+        <template v-if="isV2 && !searchActive && subcategories.length">
           <section
-            v-for="sub in subcategories"
+            v-for="sub in visibleSubcategories"
             v-show="sub.templates.length"
             :id="`subcat-${sub.slug}`"
             :key="sub.id"
             class="cat-section"
             aria-label="Sub-category templates"
           >
-            <h3 class="subcat-heading">{{ sub.name }}</h3>
+            <div class="subcat-header">
+              <span class="subcat-header__chip"><LucideIcon :name="sub.icon" :size="17" /></span>
+              <h3 class="subcat-heading">{{ sub.name }}</h3>
+              <span class="subcat-header__count">{{ sub.templates.length }} templates</span>
+            </div>
             <div v-if="sub.description" class="subcat-desc content-description" v-html="sub.description" />
             <div class="templates-grid">
-              <TemplateCard v-for="template in sub.templates" :key="`${sub.id}-${template.id}`" :template="template" />
+              <TemplateCard
+                v-for="template in sub.templates"
+                :key="`${sub.id}-${template.id}`"
+                :template="template"
+                :category-label="shortSubName(sub)"
+              />
             </div>
           </section>
         </template>
 
-        <!-- Flat grid: fallback (no sub-categories) and search results -->
+        <!-- Flat grid: fallback (non-V2) and search results -->
         <template v-else>
           <template v-if="filteredTemplates.length > 0">
             <section class="templates-grid" aria-label="Templates">
@@ -89,6 +175,7 @@
                 v-for="(template, index) in filteredTemplates"
                 :key="template.id"
                 :template="template"
+                :category-label="!searchActive && activeCategory ? activeCategory.name : ''"
                 :class="{ 'template-hidden': isClient && useViewMore && index >= visibleCount }"
               />
             </section>
@@ -108,7 +195,7 @@
         </template>
 
         <!-- Related categories -->
-        <section v-if="!searchActive && relatedCategories.length" class="related-section">
+        <section v-if="isV2 && !searchActive && relatedCategories.length" class="related-section">
           <div class="section-eyebrow">RELATED</div>
           <h2 class="section-title">Categories teams pair with {{ activeCategory.name }}</h2>
           <div class="related-grid">
@@ -116,8 +203,9 @@
               v-for="rel in relatedCategories"
               :key="rel.id"
               :to="`/templates/categories/${rel.slug}/`"
-              class="related-card"
+              class="related-card fm-card"
             >
+              <span class="related-card__chip"><LucideIcon :name="rel.icon" :size="18" /></span>
               <span class="related-card__name">{{ rel.name }}</span>
               <span v-if="rel.templateCount" class="related-card__count">{{ rel.templateCount }} templates</span>
             </NuxtLink>
@@ -125,13 +213,13 @@
         </section>
 
         <!-- Learn (super-admin authored HTML blocks) -->
-        <template v-if="!searchActive && activeCategory?.htmlBlocks?.length">
+        <template v-if="isV2 && !searchActive && activeCategory?.htmlBlocks?.length">
           <StrapiRawHtml v-for="block in activeCategory.htmlBlocks" :key="block.name" :markup="block.content" />
         </template>
 
         <!-- FAQ accordion -->
         <FaqSection
-          v-if="!searchActive && faqs.length"
+          v-if="isV2 && !searchActive && faqs.length"
           badge="FAQ"
           :title="`${activeCategory.name} templates — frequently asked questions`"
           :faq-list="faqs"
@@ -140,8 +228,8 @@
         />
 
         <!-- CTA banner -->
-        <section v-if="!searchActive && activeCategory" class="cat-cta">
-          <span class="cat-cta__eyebrow">READY WHEN YOU ARE</span>
+        <section v-if="isV2 && !searchActive && activeCategory" class="cat-cta">
+          <span class="cat-cta__eyebrow"><LucideIcon name="rocket" :size="14" /> READY WHEN YOU ARE</span>
           <h2 class="cat-cta__title">Start with a {{ activeCategory.name }} template, ship today.</h2>
           <p class="cat-cta__sub">
             Pick a ready-made template, brand it, embed it. Free plan included, no credit card.
@@ -187,6 +275,7 @@ export default {
       showFullDescription: false,
       visibleCount: 12,
       isClient: false,
+      activeFilter: null,
     }
   },
   mounted() {
@@ -197,6 +286,7 @@ export default {
       immediate: true,
       handler() {
         this.showFullDescription = false
+        this.activeFilter = null
       },
     },
   },
@@ -212,13 +302,52 @@ export default {
     viewMore() {
       this.visibleCount += 12
     },
+    // Trim words the sub-category shares with its parent, e.g.
+    // "Healthcare Consent" under "Consent Forms" → "Healthcare".
+    shortSubName(sub) {
+      const parentWords = new Set((this.activeCategory?.name || '').toLowerCase().split(/\s+/))
+      const kept = (sub.name || '').split(/\s+/).filter((w) => !parentWords.has(w.toLowerCase()))
+      return (kept.join(' ') || sub.name || '').trim()
+    },
   },
   computed: {
     searchActive() {
       return this.searchTerm.trim().length > 0
     },
+    isV2() {
+      return !!this.activeCategory?.v2Enabled
+    },
+    pageContent() {
+      return this.activeCategory?.pageContent || {}
+    },
+    featuredTitle() {
+      return this.pageContent.featuredTitle || `Most popular ${this.activeCategory?.name || ''} templates`
+    },
+    featuredSubtitle() {
+      return this.pageContent.featuredSubtitle || ''
+    },
+    heroArtBlocks() {
+      return this.activeCategory?.pageContent?.heroArtBlocks || []
+    },
+    // Hero title supports inline *asterisk* highlights (multiple allowed):
+    // "Free *consent form* templates" → "consent form" in the brand accent.
+    heroTitleTokens() {
+      const title = this.pageContent.heroTitle || ''
+      return title
+        .split(/(\*[^*]+\*)/g)
+        .filter((p) => p !== '')
+        .map((p) =>
+          p.length > 2 && p.startsWith('*') && p.endsWith('*')
+            ? { text: p.slice(1, -1), highlight: true }
+            : { text: p, highlight: false }
+        )
+    },
     subcategories() {
       return this.activeCategory?.subcategories || []
+    },
+    visibleSubcategories() {
+      if (!this.activeFilter) return this.subcategories
+      return this.subcategories.filter((s) => s.slug === this.activeFilter)
     },
     featuredTemplates() {
       return this.activeCategory?.featuredTemplates || []
@@ -241,11 +370,15 @@ export default {
         : ''
       return when ? `${count} templates · Updated ${when}` : `${count} templates`
     },
-    // Derivable stats only — no invented marketing numbers.
+    // Templates + Free are derivable; forms-shipped / setup are admin-entered
+    // (blank => omitted, so we never invent numbers).
     heroStats() {
       const stats = [{ value: String(this.categoryTemplateCount), label: 'Templates' }]
-      if (this.subcategories.length) {
-        stats.push({ value: String(this.subcategories.length), label: 'Sub-categories' })
+      if (this.pageContent.statFormsShipped) {
+        stats.push({ value: this.pageContent.statFormsShipped, label: 'Forms shipped' })
+      }
+      if (this.pageContent.statSetup) {
+        stats.push({ value: this.pageContent.statSetup, label: 'Setup' })
       }
       stats.push({ value: 'Free', label: 'Preview' })
       return stats
@@ -314,7 +447,8 @@ export default {
   margin-bottom: 1.5rem;
   min-width: 264px;
   overflow-y: scroll;
-  padding-bottom: 1.5rem;
+  padding: 0 16px 1.5rem 0;
+  border-right: 1px solid var(--clr-border, #eaecf0);
 }
 
 .left-sidebar::-webkit-scrollbar {
@@ -365,6 +499,23 @@ export default {
   line-height: 48px;
   letter-spacing: -0.64px;
   flex-shrink: 0;
+}
+
+/* V2 hero title: render as authored (sentence case) with an accent phrase.
+   flex-shrink + max-width let it wrap to ~2 lines instead of running under
+   the hero art (the base .content-heading has flex-shrink: 0). */
+.content-heading--v2 {
+  text-transform: none;
+  flex-shrink: 1;
+  min-width: 0;
+  max-width: 560px;
+  font-size: 38px;
+  line-height: 46px;
+  letter-spacing: -0.02em;
+}
+
+.hero-highlight {
+  color: var(--clr-primary, #7f56d9);
 }
 
 .description-wrapper {
@@ -474,6 +625,239 @@ export default {
   display: none;
 }
 
+/* ── Hero two-column layout + decorative art ── */
+.hero-wrap--v2 {
+  display: flex;
+  gap: 40px;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.hero-wrap--v2 .hero-left {
+  flex: 1 1 0;
+  min-width: 0;
+  max-width: 560px;
+}
+
+.hero-art {
+  flex: 1 1 0;
+  min-width: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.hero-art {
+  position: relative;
+  height: 300px;
+  width: 380px;
+  flex: 0 0 380px;
+}
+
+/* Custom (admin HTML) art: give the raw-html block the full 380×300 canvas
+   instead of the flex-centering that collapses absolutely-positioned children. */
+.hero-art--custom {
+  display: block;
+}
+.hero-art--custom :deep(section) {
+  width: 100%;
+  height: 100%;
+}
+.hero-art--custom :deep(.raw-html-content) {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.art-card {
+  position: absolute;
+  border-radius: 18px;
+  display: flex;
+  padding: 16px;
+}
+
+.art-card--amber {
+  left: 30px;
+  top: 30px;
+  width: 150px;
+  height: 188px;
+  background: #f2a33a;
+  transform: rotate(-9deg);
+  box-shadow: 0 18px 40px -12px rgba(242, 163, 58, 0.45);
+  align-items: flex-start;
+}
+
+.art-card--red {
+  right: 34px;
+  top: 14px;
+  width: 150px;
+  height: 188px;
+  background: #ef5b52;
+  transform: rotate(8deg);
+  box-shadow: 0 18px 40px -12px rgba(239, 91, 82, 0.45);
+  align-items: flex-start;
+  justify-content: flex-end;
+}
+
+.art-card--blue {
+  left: 88px;
+  top: 78px;
+  width: 170px;
+  height: 206px;
+  background: #4c8df0;
+  box-shadow: 0 24px 48px -12px rgba(76, 141, 240, 0.5);
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  padding: 18px;
+}
+
+.art-chip {
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.95);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+}
+
+.art-chip--amber,
+.art-chip--red {
+  width: 38px;
+  height: 38px;
+  border-radius: 10px;
+}
+
+.art-chip--amber {
+  color: #b8740c;
+}
+
+.art-chip--red {
+  color: #c0392b;
+}
+
+.art-chip--blue {
+  width: 46px;
+  height: 46px;
+  color: #2563eb;
+}
+
+.art-card__label {
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  text-align: center;
+  text-transform: capitalize;
+}
+
+.art-float {
+  position: absolute;
+  right: -6px;
+  bottom: 18px;
+  background: #fff;
+  border: 1px solid #eaecf0;
+  border-radius: 12px;
+  box-shadow: 0 12px 28px -8px rgba(16, 24, 40, 0.18);
+  padding: 11px 13px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+
+.art-float__chip {
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  background: #f0ebfa;
+  color: var(--clr-primary, #7f56d9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+}
+
+.art-float__text {
+  display: flex;
+  flex-direction: column;
+}
+
+.art-float__title {
+  font-size: 12px;
+  font-weight: 600;
+  color: #101828;
+}
+
+.art-float__sub {
+  font-size: 11px;
+  color: #697586;
+}
+
+.art-pill {
+  position: absolute;
+  left: 6px;
+  bottom: 50px;
+  background: #fff;
+  border-radius: 9999px;
+  box-shadow: 0 8px 20px -6px rgba(16, 24, 40, 0.16);
+  padding: 6px 11px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #067647;
+}
+
+/* ── Filter bar (search + sub-category pills, single row) ── */
+.filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 0;
+  border-top: 1px solid var(--clr-border, #eaecf0);
+  border-bottom: 1px solid var(--clr-border, #eaecf0);
+  margin: 8px 0 36px;
+  flex-wrap: nowrap;
+}
+
+.filter-bar__search {
+  flex: 0 0 280px;
+  max-width: 280px;
+}
+
+/* Compact the shared search box inside the filter bar. */
+.filter-bar__search :deep(.search-box) {
+  min-width: 0;
+  padding: 12px 16px;
+  border-radius: 8px;
+}
+
+/* Tabs take the remaining width, right-aligned; overflow scrolls sideways. */
+.filter-bar .subcat-tabs {
+  flex: 0 1 auto;
+  margin-left: auto;
+  min-width: 0;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  scrollbar-width: thin;
+  -webkit-overflow-scrolling: touch;
+  padding-bottom: 2px;
+}
+
+.filter-bar .subcat-tab {
+  flex-shrink: 0;
+}
+
+.filter-bar .subcat-tabs::-webkit-scrollbar {
+  height: 4px;
+}
+
+.filter-bar .subcat-tabs::-webkit-scrollbar-thumb {
+  background-color: #d0d5dd;
+  border-radius: 4px;
+}
+
 /* ── Hero badge + actions + stats ── */
 .hero-badge {
   display: inline-flex;
@@ -506,9 +890,9 @@ export default {
 .hero-btn {
   display: inline-flex;
   align-items: center;
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 600;
-  padding: 11px 18px;
+  padding: 9px 16px;
   border-radius: 9999px;
 }
 
@@ -582,6 +966,17 @@ export default {
   transform: translateY(-2px);
 }
 
+.related-card__chip {
+  width: 34px;
+  height: 34px;
+  border-radius: 9px;
+  background: var(--background-color-violet-25, #f0ebfa);
+  color: var(--clr-primary, #7f56d9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .related-card__name {
   font-size: 14px;
   font-weight: 600;
@@ -599,21 +994,22 @@ export default {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  margin: 24px 0 8px;
 }
 
 .subcat-tab {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 7px 14px;
+  padding: 4px 12px;
   border-radius: 9999px;
   border: 1px solid var(--clr-border, #eaecf0);
   background: #fff;
-  font-size: 13px;
+  font-family: inherit;
+  font-size: 12px;
   font-weight: 500;
   color: var(--clr-text-secondary);
   text-transform: capitalize;
+  cursor: pointer;
   transition: border-color 0.15s, color 0.15s, background 0.15s;
 }
 
@@ -622,12 +1018,28 @@ export default {
   color: var(--clr-primary);
 }
 
+.subcat-tab--active {
+  background: #101828;
+  border-color: #101828;
+  color: #fff;
+  font-weight: 600;
+}
+
+.subcat-tab--active:hover {
+  color: #fff;
+}
+
 .subcat-tab__count {
   font-size: 12px;
   color: var(--clr-text-secondary);
   background: var(--background-color-grey-50, #f5f5f5);
   border-radius: 9999px;
   padding: 0 7px;
+}
+
+.subcat-tab--active .subcat-tab__count {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.18);
 }
 
 /* ── Category content sections ── */
@@ -653,19 +1065,59 @@ export default {
   text-transform: capitalize;
 }
 
+.section-subtitle {
+  font-size: 14px;
+  color: var(--clr-text-secondary);
+  margin: 0 0 18px;
+}
+
+.hero-subtitle {
+  font-size: 16px;
+  line-height: 25px;
+  color: var(--clr-text-secondary);
+  margin: 10px 0 0;
+  max-width: 520px;
+}
+
+.subcat-header {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  margin-bottom: 5px;
+}
+
+.subcat-header__chip {
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  background: var(--background-color-violet-25, #f0ebfa);
+  color: var(--clr-primary, #7f56d9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+}
+
 .subcat-heading {
   font-size: 19px;
   font-weight: 600;
   letter-spacing: -0.01em;
   color: var(--clr-text-primary);
-  margin: 0 0 4px;
+  margin: 0;
   text-transform: capitalize;
+}
+
+.subcat-header__count {
+  margin-left: auto;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--clr-primary, #6941c6);
 }
 
 .subcat-desc {
   font-size: 14px;
   color: var(--clr-text-secondary);
-  margin: 0 0 16px;
+  margin: 0 0 16px 41px;
   max-width: 720px;
 }
 
@@ -680,7 +1132,9 @@ export default {
 }
 
 .cat-cta__eyebrow {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
   font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.06em;
@@ -743,18 +1197,28 @@ export default {
 }
 
 .breadcrumb-text {
-  font-size: 14px;
-  font-weight: 600;
+  font-size: 12px;
+  font-weight: 400;
   line-height: 20px;
-  color: var(--clr-primary);
+  color: #697586;
   text-transform: capitalize;
 }
 
+.breadcrumb-text:hover {
+  color: var(--clr-primary);
+}
+
+.breadcrumb-sep {
+  color: #697586;
+  opacity: 0.55;
+  flex-shrink: 0;
+}
+
 .breadcrumb-current {
-  font-size: 14px;
-  font-weight: 600;
+  font-size: 12px;
+  font-weight: 500;
   line-height: 20px;
-  color: var(--clr-text-secondary);
+  color: #344054;
   text-transform: capitalize;
 }
 
@@ -802,6 +1266,26 @@ export default {
     position: static;
     margin: 0;
     overflow-y: auto;
+    border-right: none;
+    padding: 0;
+  }
+  .hero-wrap--v2 {
+    flex-direction: column;
+    gap: 0;
+    align-items: stretch;
+  }
+  .hero-art {
+    display: none;
+  }
+  .filter-bar {
+    flex-wrap: wrap;
+  }
+  .filter-bar__search {
+    flex: 1 1 100%;
+    max-width: none;
+  }
+  .filter-bar .subcat-tabs {
+    margin: 8px 0 0;
   }
 }
 

--- a/components/template/Templates.vue
+++ b/components/template/Templates.vue
@@ -1283,7 +1283,15 @@ export default {
   gap: 8px;
 }
 
-@media (max-width: 991px) {
+/* Intermediate band: the sidebar (264px) + fixed 380px art leave too little
+   room for the hero text, and 3-column cards get crushed. */
+@media (max-width: 1199px) {
+  .hero-art {
+    display: none;
+  }
+  .hero-wrap--v2 .hero-left {
+    max-width: none;
+  }
   .templates-grid {
     grid-template-columns: 1fr 1fr;
     margin-top: 0;
@@ -1293,7 +1301,8 @@ export default {
   }
 }
 
-@media only screen and (max-width: 840px) {
+/* Full mobile layout — matches the navbar's hamburger breakpoint (900px). */
+@media only screen and (max-width: 900px) {
   .heading-row {
     flex-direction: column;
     align-items: flex-start;

--- a/components/template/Templates.vue
+++ b/components/template/Templates.vue
@@ -5,88 +5,155 @@
         <div class="search-row">
           <TemplateSearch @searchInput="handleSearch" />
         </div>
-        <div
-          v-if="activeCategory"
-          class="breadcrumb d-flex align-items-center gap-2"
-        >
-          <NuxtLink to="/templates/" class="breadcrumb-text">
-            All Templates
-          </NuxtLink>
+        <div v-if="activeCategory" class="breadcrumb d-flex align-items-center gap-2">
+          <NuxtLink to="/templates/" class="breadcrumb-text"> All Templates </NuxtLink>
           <img src="~/assets/images/icons/chevron-right.svg" />
           <span class="breadcrumb-current">{{ activeCategory.name }}</span>
         </div>
+        <div v-if="activeCategory && heroBadge" class="hero-badge">{{ heroBadge }}</div>
         <div class="heading-row">
           <h1 class="content-heading">
             {{ activeCategory ? activeCategory.name : 'All' }}
             Templates
           </h1>
         </div>
-        <div
-          v-if="activeCategory?.description"
-          class="my-2"
-        >
+        <div v-if="activeCategory?.description" class="my-2">
           <div
             class="description-wrapper"
             :class="{
-              'expanded': showFullDescription,
-              'description-truncated': isClient && !showFullDescription
+              expanded: showFullDescription,
+              'description-truncated': isClient && !showFullDescription,
             }"
           >
-            <div
-              class="content-description mt-0 mb-1"
-              v-html="activeCategory.description"
-            />
+            <div class="content-description mt-0 mb-1" v-html="activeCategory.description" />
           </div>
-          <button
-            v-if="isClient"
-            class="content-description-handle-button text-nowrap"
-            @click="toggleDescription"
-          >
+          <button v-if="isClient" class="content-description-handle-button text-nowrap" @click="toggleDescription">
             {{ descriptionButtonLabel }}
           </button>
         </div>
 
-        <template v-if="filteredTemplates.length > 0">
-          <section class="templates-grid" aria-label="Templates">
-            <TemplateCard
-              v-for="(template, index) in filteredTemplates"
-              :key="template.id"
-              :template="template"
-              :class="{ 'template-hidden': isClient && useViewMore && index >= visibleCount }"
-            />
+        <!-- Hero actions + derivable stats -->
+        <div v-if="activeCategory && !searchActive" class="hero-meta">
+          <div class="hero-actions">
+            <a href="/users/sign_up" class="hero-btn hero-btn--primary">Create form</a>
+            <NuxtLink to="/templates/" class="hero-btn hero-btn--ghost">Browse templates</NuxtLink>
+          </div>
+          <div v-if="heroStats.length" class="hero-stats">
+            <div v-for="stat in heroStats" :key="stat.label" class="hero-stat">
+              <span class="hero-stat__value">{{ stat.value }}</span>
+              <span class="hero-stat__label">{{ stat.label }}</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Sub-category quick-filter tabs -->
+        <div v-if="!searchActive && subcategories.length" class="subcat-tabs">
+          <a v-for="sub in subcategories" :key="sub.id" class="subcat-tab" :href="`#subcat-${sub.slug}`">
+            {{ sub.name }}
+            <span class="subcat-tab__count">{{ sub.templates.length }}</span>
+          </a>
+        </div>
+
+        <!-- Featured templates -->
+        <section v-if="!searchActive && featuredTemplates.length" class="cat-section" aria-label="Featured templates">
+          <div class="section-eyebrow">FEATURED</div>
+          <h2 class="section-title">Most popular {{ activeCategory.name }} templates</h2>
+          <div class="templates-grid">
+            <TemplateCard v-for="template in featuredTemplates" :key="`featured-${template.id}`" :template="template" />
+          </div>
+        </section>
+
+        <!-- Sub-category sections -->
+        <template v-if="!searchActive && subcategories.length">
+          <section
+            v-for="sub in subcategories"
+            v-show="sub.templates.length"
+            :id="`subcat-${sub.slug}`"
+            :key="sub.id"
+            class="cat-section"
+            aria-label="Sub-category templates"
+          >
+            <h3 class="subcat-heading">{{ sub.name }}</h3>
+            <div v-if="sub.description" class="subcat-desc content-description" v-html="sub.description" />
+            <div class="templates-grid">
+              <TemplateCard v-for="template in sub.templates" :key="`${sub.id}-${template.id}`" :template="template" />
+            </div>
           </section>
-          <div v-if="isClient && useViewMore && visibleCount < filteredTemplates.length" class="d-flex justify-content-center mt-3">
-            <button
-              @click="viewMore"
-              class="btn-primary"
-              aria-label="View more templates"
-              type="button"
+        </template>
+
+        <!-- Flat grid: fallback (no sub-categories) and search results -->
+        <template v-else>
+          <template v-if="filteredTemplates.length > 0">
+            <section class="templates-grid" aria-label="Templates">
+              <TemplateCard
+                v-for="(template, index) in filteredTemplates"
+                :key="template.id"
+                :template="template"
+                :class="{ 'template-hidden': isClient && useViewMore && index >= visibleCount }"
+              />
+            </section>
+            <div
+              v-if="isClient && useViewMore && visibleCount < filteredTemplates.length"
+              class="d-flex justify-content-center mt-3"
             >
-              View More
-            </button>
+              <button @click="viewMore" class="btn-primary" aria-label="View more templates" type="button">
+                View More
+              </button>
+            </div>
+          </template>
+          <div v-else class="no-templates d-flex flex-column align-items-center justify-content-center w-100">
+            <nuxt-img class="img-fluid" src="/templates/no-template.svg" alt="No Template Illustration" />
+            <h4 class="mt-3">No Template Available</h4>
           </div>
         </template>
-        <div v-else class="no-templates d-flex flex-column align-items-center justify-content-center w-100">
-          <nuxt-img
-            class="img-fluid"
-            src="/templates/no-template.svg"
-            alt="No Template Illustration"
-          />
-          <h4 class="mt-3">No Template Available</h4>
-        </div>
-        <template v-if="activeCategory?.htmlBlocks?.length">
-          <StrapiRawHtml
-            v-for="block in activeCategory.htmlBlocks"
-            :key="block.name"
-            :markup="block.content"
-          />
+
+        <!-- Related categories -->
+        <section v-if="!searchActive && relatedCategories.length" class="related-section">
+          <div class="section-eyebrow">RELATED</div>
+          <h2 class="section-title">Categories teams pair with {{ activeCategory.name }}</h2>
+          <div class="related-grid">
+            <NuxtLink
+              v-for="rel in relatedCategories"
+              :key="rel.id"
+              :to="`/templates/categories/${rel.slug}/`"
+              class="related-card"
+            >
+              <span class="related-card__name">{{ rel.name }}</span>
+              <span v-if="rel.templateCount" class="related-card__count">{{ rel.templateCount }} templates</span>
+            </NuxtLink>
+          </div>
+        </section>
+
+        <!-- Learn (super-admin authored HTML blocks) -->
+        <template v-if="!searchActive && activeCategory?.htmlBlocks?.length">
+          <StrapiRawHtml v-for="block in activeCategory.htmlBlocks" :key="block.name" :markup="block.content" />
         </template>
+
+        <!-- FAQ accordion -->
+        <FaqSection
+          v-if="!searchActive && faqs.length"
+          badge="FAQ"
+          :title="`${activeCategory.name} templates — frequently asked questions`"
+          :faq-list="faqs"
+          :description-fallback="false"
+          centered
+        />
+
+        <!-- CTA banner -->
+        <section v-if="!searchActive && activeCategory" class="cat-cta">
+          <span class="cat-cta__eyebrow">READY WHEN YOU ARE</span>
+          <h2 class="cat-cta__title">Start with a {{ activeCategory.name }} template, ship today.</h2>
+          <p class="cat-cta__sub">
+            Pick a ready-made template, brand it, embed it. Free plan included, no credit card.
+          </p>
+          <div class="cat-cta__btns">
+            <a href="/users/sign_up" class="cat-cta__btn cat-cta__btn--primary"> Sign up free </a>
+            <a href="/templates/" class="cat-cta__btn cat-cta__btn--ghost"> Browse templates </a>
+          </div>
+        </section>
       </div>
       <div class="left-sidebar">
-        <TemplateCategories
-          :activeCategory="activeCategory"
-          :templateCategories="templateCategories"
-        />
+        <TemplateCategories :activeCategory="activeCategory" :templateCategories="templateCategories" />
       </div>
     </div>
   </div>
@@ -96,9 +163,10 @@
 import TemplateCategories from '@/components/template/TemplateCategories.vue'
 import TemplateCard from '@/components/template/TemplateCard.vue'
 import TemplateSearch from '@/components/template/TemplateSearch.vue'
+import FaqSection from '@/components/v2/FaqSection.vue'
 
 export default {
-  components: { TemplateCategories, TemplateCard, TemplateSearch },
+  components: { TemplateCategories, TemplateCard, TemplateSearch, FaqSection },
   props: {
     activeCategory: Object,
     templates: Array,
@@ -146,19 +214,65 @@ export default {
     },
   },
   computed: {
+    searchActive() {
+      return this.searchTerm.trim().length > 0
+    },
+    subcategories() {
+      return this.activeCategory?.subcategories || []
+    },
+    featuredTemplates() {
+      return this.activeCategory?.featuredTemplates || []
+    },
+    faqs() {
+      return this.activeCategory?.faqs || []
+    },
+    relatedCategories() {
+      return this.activeCategory?.relatedCategories || []
+    },
+    categoryTemplateCount() {
+      return this.activeCategory?.templateCount || this.allCategoryTemplates.length
+    },
+    heroBadge() {
+      const count = this.categoryTemplateCount
+      if (!count) return ''
+      const updated = this.activeCategory?.updatedAt
+      const when = updated
+        ? new Date(updated).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
+        : ''
+      return when ? `${count} templates · Updated ${when}` : `${count} templates`
+    },
+    // Derivable stats only — no invented marketing numbers.
+    heroStats() {
+      const stats = [{ value: String(this.categoryTemplateCount), label: 'Templates' }]
+      if (this.subcategories.length) {
+        stats.push({ value: String(this.subcategories.length), label: 'Sub-categories' })
+      }
+      stats.push({ value: 'Free', label: 'Preview' })
+      return stats
+    },
+    // Templates of this category live across featured + sub-categories + any
+    // directly-assigned flat list. Merge + dedupe so search covers all of them.
+    allCategoryTemplates() {
+      const byId = new Map()
+      const add = (list) => (list || []).forEach((t) => byId.set(t.id, t))
+      add(this.templates)
+      add(this.featuredTemplates)
+      this.subcategories.forEach((sub) => add(sub.templates))
+      return [...byId.values()]
+    },
     useViewMore() {
       return !this.isPaginated || this.searchTerm.trim().length > 0
     },
     searchableTemplates() {
-      return this.searchTerm.trim() && this.allTemplates ? this.allTemplates : this.templates
+      if (!this.searchTerm.trim()) return this.templates
+      return this.allTemplates || this.allCategoryTemplates
     },
     filteredTemplates() {
       const searchTerm = this.searchTerm.trim().toLowerCase()
       if (!searchTerm) return this.templates
       return this.searchableTemplates.filter(
         (template) =>
-          template.name.toLowerCase().includes(searchTerm) ||
-          template.description?.toLowerCase().includes(searchTerm)
+          template.name.toLowerCase().includes(searchTerm) || template.description?.toLowerCase().includes(searchTerm)
       )
     },
     descriptionButtonLabel() {
@@ -192,7 +306,6 @@ export default {
   flex-direction: row-reverse;
   margin-top: 8rem;
 }
-
 
 .left-sidebar {
   position: sticky;
@@ -361,6 +474,265 @@ export default {
   display: none;
 }
 
+/* ── Hero badge + actions + stats ── */
+.hero-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--clr-primary);
+  background: var(--background-color-violet-25, #f7f3ff);
+  border: 1px solid #ece3ff;
+  padding: 5px 11px;
+  border-radius: 9999px;
+  margin-bottom: 12px;
+}
+
+.hero-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 32px;
+  margin: 20px 0 8px;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.hero-btn {
+  display: inline-flex;
+  align-items: center;
+  font-size: 14px;
+  font-weight: 600;
+  padding: 11px 18px;
+  border-radius: 9999px;
+}
+
+.hero-btn--primary {
+  color: #fff;
+  background: var(--clr-primary);
+}
+
+.hero-btn--primary:hover {
+  background: var(--clr-primary-hover);
+}
+
+.hero-btn--ghost {
+  color: var(--clr-text-primary);
+  background: #fff;
+  border: 1px solid var(--clr-border, #d0d5dd);
+}
+
+.hero-stats {
+  display: flex;
+  gap: 36px;
+  flex-wrap: wrap;
+}
+
+.hero-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.hero-stat__value {
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--clr-text-primary);
+}
+
+.hero-stat__label {
+  font-size: 12px;
+  color: var(--clr-text-secondary);
+}
+
+/* ── Related categories ── */
+.related-section {
+  margin-top: 48px;
+  background: var(--background-color-grey-50, #f9fafb);
+  border: 1px solid var(--clr-border, #eaecf0);
+  border-radius: 16px;
+  padding: 28px;
+}
+
+.related-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 14px;
+  margin-top: 18px;
+}
+
+.related-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background: #fff;
+  border: 1px solid var(--clr-border, #eaecf0);
+  border-radius: 12px;
+  padding: 16px;
+  transition: box-shadow 0.15s, transform 0.15s;
+}
+
+.related-card:hover {
+  box-shadow: 0 8px 24px -6px rgba(16, 24, 40, 0.12);
+  transform: translateY(-2px);
+}
+
+.related-card__name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--clr-text-primary);
+  text-transform: capitalize;
+}
+
+.related-card__count {
+  font-size: 12px;
+  color: var(--clr-text-secondary);
+}
+
+/* ── Sub-category quick-filter tabs ── */
+.subcat-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 24px 0 8px;
+}
+
+.subcat-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 14px;
+  border-radius: 9999px;
+  border: 1px solid var(--clr-border, #eaecf0);
+  background: #fff;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--clr-text-secondary);
+  text-transform: capitalize;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+
+.subcat-tab:hover {
+  border-color: var(--clr-primary);
+  color: var(--clr-primary);
+}
+
+.subcat-tab__count {
+  font-size: 12px;
+  color: var(--clr-text-secondary);
+  background: var(--background-color-grey-50, #f5f5f5);
+  border-radius: 9999px;
+  padding: 0 7px;
+}
+
+/* ── Category content sections ── */
+.cat-section {
+  margin-top: 40px;
+  scroll-margin-top: 90px;
+}
+
+.section-eyebrow {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  color: var(--clr-text-secondary);
+  margin-bottom: 6px;
+}
+
+.section-title {
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  color: var(--clr-text-primary);
+  margin: 0 0 18px;
+  text-transform: capitalize;
+}
+
+.subcat-heading {
+  font-size: 19px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--clr-text-primary);
+  margin: 0 0 4px;
+  text-transform: capitalize;
+}
+
+.subcat-desc {
+  font-size: 14px;
+  color: var(--clr-text-secondary);
+  margin: 0 0 16px;
+  max-width: 720px;
+}
+
+/* ── CTA banner ── */
+.cat-cta {
+  margin-top: 56px;
+  border-radius: 20px;
+  padding: 52px 32px;
+  text-align: center;
+  background: radial-gradient(60% 120% at 50% -10%, rgba(127, 86, 217, 0.55), transparent 70%), #2a1d66;
+  color: #fff;
+}
+
+.cat-cta__eyebrow {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: #cdbcff;
+  margin-bottom: 14px;
+}
+
+.cat-cta__title {
+  font-size: 28px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  color: #fff;
+  margin: 0 auto 10px;
+  max-width: 460px;
+  line-height: 36px;
+  text-transform: capitalize;
+}
+
+.cat-cta__sub {
+  font-size: 15px;
+  color: #cbc3ec;
+  margin: 0 auto 24px;
+  max-width: 440px;
+}
+
+.cat-cta__btns {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.cat-cta__btn {
+  display: inline-flex;
+  align-items: center;
+  font-size: 14px;
+  font-weight: 600;
+  padding: 11px 20px;
+  border-radius: 9999px;
+}
+
+.cat-cta__btn--primary {
+  color: #53389e;
+  background: #fff;
+}
+
+.cat-cta__btn--ghost {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.28);
+}
+
 .no-templates {
   padding: 52px 0;
   gap: 1rem;
@@ -394,6 +766,9 @@ export default {
   .templates-grid {
     grid-template-columns: 1fr 1fr;
     margin-top: 0;
+  }
+  .related-grid {
+    grid-template-columns: repeat(3, 1fr);
   }
 }
 
@@ -433,6 +808,9 @@ export default {
 @media only screen and (max-width: 600px) {
   .templates-grid {
     grid-template-columns: 1fr;
+  }
+  .related-grid {
+    grid-template-columns: 1fr 1fr;
   }
 }
 </style>

--- a/components/template/Templates.vue
+++ b/components/template/Templates.vue
@@ -141,6 +141,7 @@
               :key="`featured-${template.id}`"
               :template="template"
               :category-label="activeCategory.name"
+              @preview="openPreview"
             />
           </div>
         </section>
@@ -167,6 +168,25 @@
                 :key="`${sub.id}-${template.id}`"
                 :template="template"
                 :category-label="shortSubName(sub)"
+                @preview="openPreview"
+              />
+            </div>
+          </section>
+
+          <!-- Directly-assigned templates that are neither featured nor in a sub-category -->
+          <section
+            v-if="!activeFilter && unsectionedTemplates.length"
+            class="cat-section"
+            aria-label="More templates"
+          >
+            <h3 class="subcat-heading">More {{ activeCategory.name }} templates</h3>
+            <div class="templates-grid">
+              <TemplateCard
+                v-for="template in unsectionedTemplates"
+                :key="`more-${template.id}`"
+                :template="template"
+                :category-label="activeCategory.name"
+              @preview="openPreview"
               />
             </div>
           </section>
@@ -182,6 +202,7 @@
                 :template="template"
                 :category-label="!searchActive && activeCategory ? activeCategory.name : ''"
                 :class="{ 'template-hidden': isClient && useViewMore && index >= visibleCount }"
+                @preview="openPreview"
               />
             </section>
             <div
@@ -249,6 +270,7 @@
         <TemplateCategories :activeCategory="activeCategory" :templateCategories="templateCategories" />
       </div>
     </div>
+    <TemplatePreviewModal :is-open="!!previewUrl" :survey-url="previewUrl || ''" @close="closePreview" />
   </div>
 </template>
 
@@ -257,9 +279,10 @@ import TemplateCategories from '@/components/template/TemplateCategories.vue'
 import TemplateCard from '@/components/template/TemplateCard.vue'
 import TemplateSearch from '@/components/template/TemplateSearch.vue'
 import FaqSection from '@/components/v2/FaqSection.vue'
+import TemplatePreviewModal from '@/components/v2/template/TemplatePreviewModal.vue'
 
 export default {
-  components: { TemplateCategories, TemplateCard, TemplateSearch, FaqSection },
+  components: { TemplateCategories, TemplateCard, TemplateSearch, FaqSection, TemplatePreviewModal },
   props: {
     activeCategory: Object,
     templates: Array,
@@ -281,6 +304,7 @@ export default {
       visibleCount: 12,
       isClient: false,
       activeFilter: null,
+      previewUrl: null,
     }
   },
   mounted() {
@@ -304,6 +328,14 @@ export default {
     toggleDescription() {
       this.showFullDescription = !this.showFullDescription
     },
+    openPreview(template) {
+      this.previewUrl = template.surveyUrl
+      document.body.style.overflow = 'hidden'
+    },
+    closePreview() {
+      this.previewUrl = null
+      document.body.style.overflow = ''
+    },
     viewMore() {
       this.visibleCount += 12
     },
@@ -324,10 +356,10 @@ export default {
     isV2() {
       return !!this.activeCategory
     },
-    // No curated hero copy yet => "default view": description + Show more
-    // instead of CTAs/stats.
+    // The hero subtitle replaces the old description; until it's curated the
+    // page keeps the description + Show more and hides the CTAs/stats.
     hasHeroContent() {
-      return !!(this.pageContent.heroTitle || this.pageContent.heroSubtitle)
+      return !!this.pageContent.heroSubtitle
     },
     pageContent() {
       return this.activeCategory?.pageContent || {}
@@ -385,6 +417,13 @@ export default {
       }
       stats.push({ value: 'Free', label: 'Preview' })
       return stats
+    },
+    // Directly-assigned templates that would otherwise be invisible on a
+    // category with sub-categories (not featured, not in any sub).
+    unsectionedTemplates() {
+      const sectioned = new Set(this.featuredTemplates.map((t) => t.id))
+      this.subcategories.forEach((sub) => (sub.templates || []).forEach((t) => sectioned.add(t.id)))
+      return (this.templates || []).filter((t) => !sectioned.has(t.id))
     },
     // Templates of this category live across featured + sub-categories + any
     // directly-assigned flat list. Merge + dedupe so search covers all of them.
@@ -507,6 +546,13 @@ export default {
 /* V2 hero title: render as authored (sentence case) with an accent phrase.
    flex-shrink + max-width let it wrap to ~2 lines instead of running under
    the hero art (the base .content-heading has flex-shrink: 0). */
+/* Default-view titles (no heroTitle) must also wrap inside the hero column
+   instead of running under the art — the base rule has flex-shrink: 0. */
+.hero-wrap--v2 .content-heading {
+  flex-shrink: 1;
+  min-width: 0;
+}
+
 .content-heading--v2 {
   text-transform: none;
   flex-shrink: 1;
@@ -617,6 +663,7 @@ export default {
   background: transparent;
   text-decoration: underline;
   margin-top: 4px;
+  font-size: 14px;
 }
 
 .templates-grid {
@@ -715,9 +762,10 @@ export default {
   box-shadow: 0 24px 48px -12px rgba(76, 141, 240, 0.5);
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  /* Content sits high so the floating pill/count cards never cover the label. */
+  justify-content: flex-start;
   gap: 14px;
-  padding: 18px;
+  padding: 34px 18px 18px;
 }
 
 .art-chip {
@@ -752,7 +800,7 @@ export default {
 
 .art-card__label {
   color: #fff;
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 600;
   line-height: 1.3;
   text-align: center;
@@ -768,8 +816,8 @@ export default {
 
 .art-float {
   position: absolute;
-  right: -6px;
-  bottom: 18px;
+  right: 4px;
+  bottom: 12px;
   background: #fff;
   border: 1px solid #eaecf0;
   border-radius: 12px;
@@ -799,19 +847,21 @@ export default {
 
 .art-float__title {
   font-size: 12px;
+  line-height: 20px;
   font-weight: 600;
   color: #101828;
 }
 
 .art-float__sub {
   font-size: 11px;
+  line-height: 16px;
   color: #697586;
 }
 
 .art-pill {
   position: absolute;
-  left: 6px;
-  bottom: 50px;
+  left: 0;
+  bottom: 6px;
   background: #fff;
   border-radius: 9999px;
   box-shadow: 0 8px 20px -6px rgba(16, 24, 40, 0.16);
@@ -851,7 +901,6 @@ export default {
 .filter-bar__search :deep(.search-box) {
   min-width: 0;
   padding: 12px 16px;
-  border-radius: 8px;
 }
 
 /* Tabs take the remaining width, right-aligned; overflow scrolls sideways. */
@@ -880,11 +929,12 @@ export default {
 }
 
 /* ── Hero actions + stats ── */
+/* Actions and stats stack as two separate rows. */
 .hero-meta {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 32px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 24px;
   margin: 20px 0 8px;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@builder.io/partytown": "^0.10.3",
         "@kyvg/vue3-notification": "^3.4.2",
+        "@lucide/vue": "^1.23.0",
         "@nuxt/content": "^2.13.2",
         "@nuxt/image": "^1.8.1",
         "@nuxtjs/robots": "^4.1.7",
@@ -18,7 +19,6 @@
         "@vite-pwa/nuxt": "^0.10.5",
         "axios": "^1.13.2",
         "bootstrap": "^5.3.3",
-        "lucide-vue-next": "^1.0.0",
         "marked": "^4.3.0",
         "nuxt-gtag": "^3.0.1",
         "nuxt-jsonld": "^2.2.1",
@@ -2442,6 +2442,15 @@
       "license": "MIT",
       "peerDependencies": {
         "vue": "^3.0.0"
+      }
+    },
+    "node_modules/@lucide/vue": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@lucide/vue/-/vue-1.23.0.tgz",
+      "integrity": "sha512-9SIYeY5K+R1iv8F8JUKMGSL7Pck/86BJ8djtZz/lnYsoHtKFUj1H2z6+PvKnC/8blZ8tqTDeDXAoTKobuX80hg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "vue": ">=3.0.1"
       }
     },
     "node_modules/@mapbox/node-pre-gyp": {
@@ -12022,16 +12031,6 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/lucide-vue-next": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lucide-vue-next/-/lucide-vue-next-1.0.0.tgz",
-      "integrity": "sha512-V6SPvx1IHTj/UY+FrIYWV5faISsPSb8BnWSFDxAtezWKvWc9ZZ40PDrdu1/Qb5vg4lHWr1hs1BAMGVGm6V1Xdg==",
-      "deprecated": "Package deprecated. Please use @lucide/vue instead.",
-      "license": "ISC",
-      "peerDependencies": {
-        "vue": ">=3.0.1"
       }
     },
     "node_modules/lz-string": {
@@ -21740,6 +21739,12 @@
       "integrity": "sha512-CZ2zOdXsbGCtWbdqMgbusKtZTkMT+dYpw9bmAitsdSNHT0knh4njD8X95JIyTMWvNVjhDkFedbkNiZLcPqttwQ==",
       "requires": {}
     },
+    "@lucide/vue": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@lucide/vue/-/vue-1.23.0.tgz",
+      "integrity": "sha512-9SIYeY5K+R1iv8F8JUKMGSL7Pck/86BJ8djtZz/lnYsoHtKFUj1H2z6+PvKnC/8blZ8tqTDeDXAoTKobuX80hg==",
+      "requires": {}
+    },
     "@mapbox/node-pre-gyp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-2.0.0.tgz",
@@ -27746,12 +27751,6 @@
       "requires": {
         "yallist": "^3.0.2"
       }
-    },
-    "lucide-vue-next": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lucide-vue-next/-/lucide-vue-next-1.0.0.tgz",
-      "integrity": "sha512-V6SPvx1IHTj/UY+FrIYWV5faISsPSb8BnWSFDxAtezWKvWc9ZZ40PDrdu1/Qb5vg4lHWr1hs1BAMGVGm6V1Xdg==",
-      "requires": {}
     },
     "lz-string": {
       "version": "1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@vite-pwa/nuxt": "^0.10.5",
         "axios": "^1.13.2",
         "bootstrap": "^5.3.3",
+        "lucide-vue-next": "^1.0.0",
         "marked": "^4.3.0",
         "nuxt-gtag": "^3.0.1",
         "nuxt-jsonld": "^2.2.1",
@@ -12021,6 +12022,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-vue-next": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lucide-vue-next/-/lucide-vue-next-1.0.0.tgz",
+      "integrity": "sha512-V6SPvx1IHTj/UY+FrIYWV5faISsPSb8BnWSFDxAtezWKvWc9ZZ40PDrdu1/Qb5vg4lHWr1hs1BAMGVGm6V1Xdg==",
+      "deprecated": "Package deprecated. Please use @lucide/vue instead.",
+      "license": "ISC",
+      "peerDependencies": {
+        "vue": ">=3.0.1"
       }
     },
     "node_modules/lz-string": {
@@ -27735,6 +27746,12 @@
       "requires": {
         "yallist": "^3.0.2"
       }
+    },
+    "lucide-vue-next": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lucide-vue-next/-/lucide-vue-next-1.0.0.tgz",
+      "integrity": "sha512-V6SPvx1IHTj/UY+FrIYWV5faISsPSb8BnWSFDxAtezWKvWc9ZZ40PDrdu1/Qb5vg4lHWr1hs1BAMGVGm6V1Xdg==",
+      "requires": {}
     },
     "lz-string": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@builder.io/partytown": "^0.10.3",
     "@kyvg/vue3-notification": "^3.4.2",
+    "@lucide/vue": "^1.23.0",
     "@nuxt/content": "^2.13.2",
     "@nuxt/image": "^1.8.1",
     "@nuxtjs/robots": "^4.1.7",
@@ -26,7 +27,6 @@
     "@vite-pwa/nuxt": "^0.10.5",
     "axios": "^1.13.2",
     "bootstrap": "^5.3.3",
-    "lucide-vue-next": "^1.0.0",
     "marked": "^4.3.0",
     "nuxt-gtag": "^3.0.1",
     "nuxt-jsonld": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@vite-pwa/nuxt": "^0.10.5",
     "axios": "^1.13.2",
     "bootstrap": "^5.3.3",
+    "lucide-vue-next": "^1.0.0",
     "marked": "^4.3.0",
     "nuxt-gtag": "^3.0.1",
     "nuxt-jsonld": "^2.2.1",

--- a/pages/templates/categories/[slug].vue
+++ b/pages/templates/categories/[slug].vue
@@ -1,51 +1,48 @@
 <template>
-  <Templates
-    :activeCategory="activeCategory"
-    :templates="templates"
-    :templateCategories="categories"
-  />
+  <Templates :activeCategory="activeCategory" :templates="templates" :templateCategories="categories" />
 </template>
 
 <script setup>
 import Templates from '@/components/template/Templates.vue'
 import getSiteMeta from '@/utils/getSiteMeta'
 import getTemplatesAndCategories, { getCategorieRoutes } from '@/utils/getTemplatesAndCategories'
+import fetchWithRetry from '@/utils/fetchWithRetry'
+import { APP_URL } from '@/constants/urls'
 
 const route = useRoute()
 
 const slug = computed(() => route.params.slug)
 
 const { data } = await useAsyncData(`template-category-${slug.value}`, async () => {
-  const [result, categorieRoutes] = await Promise.all([
+  const [result, categorieRoutes, richRes] = await Promise.all([
     getTemplatesAndCategories(),
     getCategorieRoutes(),
+    // Rich landing payload: sub-categories (with templates), featured, faqs, html blocks.
+    // Optional — falls back gracefully to the flat category if it fails.
+    fetchWithRetry(`${APP_URL}/template_categories/${slug.value}.json`).catch(() => null),
   ])
-  const categoryRoute = categorieRoutes?.find(
-    (cate) => cate.route === `/templates/categories/${slug.value}`
-  )
+  const categoryRoute = categorieRoutes?.find((cate) => cate.route === `/templates/categories/${slug.value}`)
   return {
     templates: categoryRoute?.payload?.templates || [],
-    categories: result.categories
+    categories: result.categories,
+    richCategory: richRes?.data?.category || null,
   }
 })
 
 const categories = computed(() => data.value?.categories || {})
 const templates = computed(() => data.value?.templates || [])
+const richCategory = computed(() => data.value?.richCategory || null)
 
 const findCategoryBySlug = (slugValue) => {
   const allCategories = Object.values(categories.value).flatMap((arr) => arr)
   return allCategories.find((category) => category.slug === slugValue)
 }
 
-const activeCategory = computed(() => findCategoryBySlug(slug.value))
+// Prefer the rich landing payload (sub-categories/featured/faqs); fall back to
+// the flat category from the grouped list when the endpoint is unavailable.
+const activeCategory = computed(() => richCategory.value || findCategoryBySlug(slug.value))
 
-const currentCategory = computed(() => {
-  const allCategories = Object.values(categories.value).flat()
-  const currentCategory = allCategories.find(
-    (cate) => cate.slug === route.params.slug
-  )
-  return currentCategory || {}
-})
+const currentCategory = computed(() => activeCategory.value || {})
 
 const currentCategoryName = computed(() => currentCategory.value.name || '')
 

--- a/utils/getTemplatesAndCategories.js
+++ b/utils/getTemplatesAndCategories.js
@@ -6,9 +6,7 @@ let cachePromise = null
 let categorieRoutesPromise = null
 
 async function _fetchTemplatesAndCategories(options = {}) {
-  console.log(
-    '[getTemplatesAndCategories] Fetching all templates and categories...',
-  )
+  console.log('[getTemplatesAndCategories] Fetching all templates and categories...')
   const cacheBust = options.no_cache ? { no_cache: true } : {}
 
   let { data: templates } = await fetchWithRetry(`${APP_URL}/templates.json`, {
@@ -20,10 +18,16 @@ async function _fetchTemplatesAndCategories(options = {}) {
     },
   })
 
-  const { data: categories } = await fetchWithRetry(
-    `${APP_URL}/template_categories.json`,
-    { params: cacheBust },
-  )
+  const { data: categories } = await fetchWithRetry(`${APP_URL}/template_categories.json`, { params: cacheBust })
+
+  // Drop sub-categories (those with a parent) from the grouped list — they are
+  // surfaced nested inside their parent's landing payload, not as top-level
+  // sidebar entries.
+  Object.keys(categories).forEach((kind) => {
+    if (Array.isArray(categories[kind])) {
+      categories[kind] = categories[kind].filter((c) => !c.parentId)
+    }
+  })
 
   const dummyDescription =
     'Check out this pre-designed template and start customising with just a single click. Personalise with your branding, incorporate electronic signatures for security and add multiple collaborators to make changes simultaneously. Use this template and start getting data driven actionable insights with robust analytics.'
@@ -43,13 +47,16 @@ async function _fetchTemplatesAndCategories(options = {}) {
     })
   )
 
-  const toCardShape = ({ id, slug, name, description, previewImageUrl }) =>
-    ({ id, slug, name, description, previewImageUrl })
+  const toCardShape = ({ id, slug, name, description, previewImageUrl }) => ({
+    id,
+    slug,
+    name,
+    description,
+    previewImageUrl,
+  })
 
   const templateRoutes = templates.map((template) => {
-    const pdfTemplate = data.find(
-      (pdfTemplate) => pdfTemplate.slug === template.slug,
-    )
+    const pdfTemplate = data.find((pdfTemplate) => pdfTemplate.slug === template.slug)
     return {
       route: `/templates/${template.slug}`,
       payload: { template, categories, data: pdfTemplate },
@@ -62,9 +69,7 @@ async function _fetchTemplatesAndCategories(options = {}) {
 
   const result = { templateRoutes, templates, categories }
 
-  console.log(
-    `[getTemplatesAndCategories] Cached ${templates.length} templates`,
-  )
+  console.log(`[getTemplatesAndCategories] Cached ${templates.length} templates`)
   return result
 }
 
@@ -84,7 +89,7 @@ async function _fetchCategorieRoutes() {
   console.log('[getTemplatesAndCategories] Fetching grouped_by_category...')
   const { categories } = await getTemplatesAndCategories()
   const { data: templatesGroupedByCategory } = await fetchWithRetry(
-    `${APP_URL}/template_categories/grouped_by_category.json`,
+    `${APP_URL}/template_categories/grouped_by_category.json`
   )
   return templatesGroupedByCategory.map((item) => ({
     route: `/templates/categories/${item.categorySlug}`,
@@ -109,11 +114,7 @@ export async function getCategorieRoutes() {
  * @param {Array} specificSlugs - Optional array of specific template slugs to filter by
  * @returns {Array} Array of random templates
  */
-export const getRandomTemplates = async (
-  count = 6,
-  categorySlug = null,
-  specificSlugs = null,
-) => {
+export const getRandomTemplates = async (count = 6, categorySlug = null, specificSlugs = null) => {
   const { templates } = await getTemplatesAndCategories()
 
   let filteredTemplates = templates
@@ -125,9 +126,7 @@ export const getRandomTemplates = async (
 
   // Filter by category if provided
   if (categorySlug) {
-    filteredTemplates = templates.filter((template) =>
-      template.categories?.some((cat) => cat.slug === categorySlug),
-    )
+    filteredTemplates = templates.filter((template) => template.categories?.some((cat) => cat.slug === categorySlug))
   }
 
   // Return empty array if not enough templates

--- a/utils/getTemplatesAndCategories.js
+++ b/utils/getTemplatesAndCategories.js
@@ -20,15 +20,6 @@ async function _fetchTemplatesAndCategories(options = {}) {
 
   const { data: categories } = await fetchWithRetry(`${APP_URL}/template_categories.json`, { params: cacheBust })
 
-  // Drop sub-categories (those with a parent) from the grouped list — they are
-  // surfaced nested inside their parent's landing payload, not as top-level
-  // sidebar entries.
-  Object.keys(categories).forEach((kind) => {
-    if (Array.isArray(categories[kind])) {
-      categories[kind] = categories[kind].filter((c) => !c.parentId)
-    }
-  })
-
   const dummyDescription =
     'Check out this pre-designed template and start customising with just a single click. Personalise with your branding, incorporate electronic signatures for security and add multiple collaborators to make changes simultaneously. Use this template and start getting data driven actionable insights with robust analytics.'
 


### PR DESCRIPTION
## What

New rich landing page for template categories with `v2_enabled` (backend PR: formester/formester-app#2822). Non-V2 categories keep the existing flat grid.

- Hero with editable title (inline `*asterisk*` accent highlights), subtitle, stats, and an optional custom HTML side asset authored from the admin
- Sidebar grouped by kind (By Purpose / Department / Industry / PDF Templates) with lucide icons, counts, and a category search
- Sub-category filter pills + per-section template groups
- Richer template cards: category label, working Preview / Use template buttons (same behavior as the template detail page)
- Related categories and FAQ sections
- `LucideIcon` wrapper component (adds `lucide-vue-next`)
- Shared search input debounced (250ms)

## Testing
Verified against a local backend on consent-forms (V2: hero, custom art block, sub-category tabs, related) and contact-forms (non-V2: unchanged flat grid).

## Deploy link
https://formester-revamp.vercel.app/
https://formester-revamp.vercel.app/templates/categories/consent-forms/