### PR TITLE
fix: add monday-app-association.json to public root

### DIFF
--- a/public/monday-app-association.json
+++ b/public/monday-app-association.json
@@ -1,0 +1,1 @@
+{"apps":[{"clientID":"2c879f1fa156f41ba8114f4b6f79f7ca"}]}


### PR DESCRIPTION
## Summary
- `app.formester.com/monday-app-association.json` correctly serves `{"apps":[{"clientID":"2c879f1fa156f41ba8114f4b6f79f7ca"}]}`
- `formester.com/monday-app-association.json` was returning the SPA HTML fallback instead of JSON, since the file didn't exist in `public/`
- Added `public/monday-app-association.json` with the matching content so it's served as a static asset

## Test plan
- [ ] After deploy, confirm `https://formester.com/monday-app-association.json` returns the JSON (not HTML) and matches `https://app.formester.com/monday-app-association.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)