### PR TITLE
feat: show Product Hunt banner site-wide

### DIFF
--- a/components/blog/BlogPostView.vue
+++ b/components/blog/BlogPostView.vue
@@ -403,7 +403,7 @@ a.art-author__name:hover {
 
 .art-toc {
   position: sticky;
-  top: 104px;
+  top: calc(104px + var(--banner-h, 0px));
   align-self: start;
   max-height: calc(100vh - 130px);
   overflow-y: auto;
@@ -460,7 +460,7 @@ a.art-author__name:hover {
 
 .art-share {
   position: sticky;
-  top: 104px;
+  top: calc(104px + var(--banner-h, 0px));
   align-self: start;
   display: flex;
   flex-direction: column;
@@ -649,7 +649,7 @@ a.art-author__name:hover {
   color: var(--fg-1);
   margin-top: 44px;
   margin-bottom: 16px;
-  scroll-margin-top: 96px;
+  scroll-margin-top: calc(96px + var(--banner-h, 0px));
 }
 
 .nuxt-content h3 {
@@ -660,7 +660,7 @@ a.art-author__name:hover {
   color: var(--fg-1);
   margin-top: 30px;
   margin-bottom: 12px;
-  scroll-margin-top: 96px;
+  scroll-margin-top: calc(96px + var(--banner-h, 0px));
 }
 
 .nuxt-content strong {

--- a/components/comparision/FormBuilderComparisonTable.vue
+++ b/components/comparision/FormBuilderComparisonTable.vue
@@ -285,7 +285,7 @@ function onPlanChange(e) {
 
 .formbuilder__logo-container {
   position: sticky;
-  top: 86px;
+  top: calc(86px + var(--banner-h, 0px));
   background: white;
   padding-left: 354px;
   z-index: 100;

--- a/components/integrations/IntegrationsDirectory.vue
+++ b/components/integrations/IntegrationsDirectory.vue
@@ -273,7 +273,7 @@ const hubIcons = computed(() => {
   max-width: 1120px;
   margin: 0 auto;
   padding: var(--space-16) var(--space-6);
-  scroll-margin-top: 90px;
+  scroll-margin-top: calc(90px + var(--banner-h, 0px));
 }
 
 .dir__header {

--- a/components/template/Templates.vue
+++ b/components/template/Templates.vue
@@ -484,7 +484,7 @@ export default {
 
 .left-sidebar {
   position: sticky;
-  top: 80px;
+  top: calc(80px + var(--banner-h, 0px));
   max-height: calc(100vh - 70px);
   margin-bottom: 1.5rem;
   min-width: 264px;
@@ -1102,7 +1102,7 @@ export default {
 /* ── Category content sections ── */
 .cat-section {
   margin-top: 40px;
-  scroll-margin-top: 90px;
+  scroll-margin-top: calc(90px + var(--banner-h, 0px));
 }
 
 .section-eyebrow {

--- a/components/v2/FaqSection.vue
+++ b/components/v2/FaqSection.vue
@@ -121,7 +121,7 @@ const toggle = (id) => {
     width: 38%;
     flex-shrink: 0;
     position: sticky;
-    top: 6rem;
+    top: calc(6rem + var(--banner-h, 0px));
     align-self: flex-start;
   }
 }

--- a/components/v2/StickyStepsSection.vue
+++ b/components/v2/StickyStepsSection.vue
@@ -88,7 +88,7 @@ defineProps({
 
   .steps-left {
     position: sticky;
-    top: 90px;
+    top: calc(90px + var(--banner-h, 0px));
   }
 }
 

--- a/components/v2/template/TemplateDetail.vue
+++ b/components/v2/template/TemplateDetail.vue
@@ -63,7 +63,7 @@ onMounted(() => {
 .tmpl-detail__sticky-header {
   position: sticky;
   /* stick when hero has scrolled fully out; 80px = site navbar height */
-  top: calc(-1 * var(--hero-h, 0px) + 80px);
+  top: calc(-1 * var(--hero-h, 0px) + 80px + var(--banner-h, 0px));
   z-index: 20;
   background: var(--bg-primary);
 }

--- a/components/v2/template/TemplateHero.vue
+++ b/components/v2/template/TemplateHero.vue
@@ -157,7 +157,7 @@ function openPreviewModal() {
 /* ── Preview column ── */
 .tmpl-detail__preview-col {
   position: sticky;
-  top: 80px;
+  top: calc(80px + var(--banner-h, 0px));
   align-self: start;
   min-width: 0;
 }
@@ -165,7 +165,7 @@ function openPreviewModal() {
 /* ── Info column ── */
 .tmpl-detail__info-col {
   position: sticky;
-  top: 80px;
+  top: calc(80px + var(--banner-h, 0px));
   align-self: start;
   display: flex;
   flex-direction: column;

--- a/components/v2/template/TemplateOverviewPanel.vue
+++ b/components/v2/template/TemplateOverviewPanel.vue
@@ -124,7 +124,7 @@ const formattedDate = computed(() => {
 /* Sidebar */
 .tmpl-detail__sidebar {
   position: sticky;
-  top: 170px;
+  top: calc(170px + var(--banner-h, 0px));
   display: flex;
   flex-direction: column;
   gap: var(--space-6);

--- a/components/v2/template/TemplatePreviewPanel.vue
+++ b/components/v2/template/TemplatePreviewPanel.vue
@@ -118,7 +118,7 @@ defineExpose({ openModal: formModal.open })
   width: 100%;
   min-width: 0;
   position: sticky;
-  top: 80px;
+  top: calc(80px + var(--banner-h, 0px));
 }
 
 .preview-shell {

--- a/components/v2/template/TemplateTabContent.vue
+++ b/components/v2/template/TemplateTabContent.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="template.tabs?.length" ref="contentRef" class="tmpl-detail__content-area" :style="{ 'scroll-margin-top': scrollOffset + 'px' }">
+  <div v-if="template.tabs?.length" ref="contentRef" class="tmpl-detail__content-area" :style="{ 'scroll-margin-top': `calc(${scrollOffset}px + var(--banner-h, 0px))` }">
     <div v-for="tab in template.tabs" :key="tab.id" v-show="activeTabId === tab.id">
       <component :is="resolvedComponents[tab.type]" v-bind="tab.props" />
     </div>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -24,7 +24,7 @@ export default {
   },
   computed: {
     showBanner() {
-      return this.$route.path === '/' && !this.bannerDismissed
+      return !this.bannerDismissed
     },
   },
   mounted() {

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -288,7 +288,7 @@ useJsonld(() => jsonldData.value)
 <style scoped>
 .read-progress {
   position: fixed;
-  top: 0;
+  top: var(--banner-h, 0px);
   left: 0;
   right: 0;
   height: 3px;


### PR DESCRIPTION
Follow-up to #875. That PR was merged at its first commit, so master currently shows the launch banner on `/` only. This makes it site-wide.

## The one-line change

`layouts/default.vue`:

```diff
-return this.$route.path === '/' && !this.bannerDismissed
+return !this.bannerDismissed
```

## Why the other 12 files

The banner is `position: fixed`, so it pushes the floating navbar down 44px. Sticky sidebars and anchor scroll offsets across the site were tuned to clear the navbar at its old position — before patching, the blog TOC and share rail slid *under* the navbar on any scrolled article.

All of them became `calc(<original> + var(--banner-h, 0px))`:

| Area | Files |
|---|---|
| Blog | `BlogPostView.vue` — TOC + share sticky (104px), heading `scroll-margin-top` (96px) |
| Templates | `TemplateHero`, `TemplatePreviewPanel` (80px), `TemplateOverviewPanel` (170px), `TemplateDetail` (calc with `--hero-h`), `TemplateTabContent` (inline `scrollOffset`), `Templates.vue` (80px + 90px) |
| Other | `IntegrationsDirectory` (90px), `FormBuilderComparisonTable` (86px), `StickyStepsSection` (90px), `FaqSection` (6rem) |

`pages/blog/[slug].vue` — read-progress bar `top: 0` → `top: var(--banner-h, 0px)`, so it stops drawing over the banner.

**`--banner-h` defaults to `0px` and is only set while the banner renders**, so with the banner gone every patched value computes to exactly what it does today. That is also the teardown path.

## Verification

- `npm run build` passes (exit 0); banner confirmed in prerendered output for `/`, `/pricing/`, `/templates/`, and a blog post
- Scripted check at 1440px on `/blog/*`, `/pricing/`, `/templates/` scrolled down: **zero** sticky elements land above the navbar's bottom edge (2 offenders on blog before the patch)
- Dismiss verified by click and by reload with `formester_ph_banner_dismissed` already set — navbar returns to `top: 12px`, `.main-content` padding to `0px`, no leftover gap
- Screenshots checked at 1440px and 390px

## Teardown

Revert this PR to go back to homepage-only, or revert both this and #875 to remove the banner entirely. The `--banner-h` hooks are harmless to leave in place and reusable for the next promo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)